### PR TITLE
Fix unhandled exception for games with >400 channels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp>2.0,<4.0
 pystray
+websockets

--- a/twitch.py
+++ b/twitch.py
@@ -49,6 +49,8 @@ from constants import (
     WebsocketTopic,
 )
 
+from exceptions import MinerException
+
 if TYPE_CHECKING:
     from gui import LoginForm
     from main import ParsedArgs
@@ -293,7 +295,15 @@ class Twitch:
                         )
                         for channel_id in self.channels
                     ]
-                    self.websocket.add_topics(topics)
+
+                    try:
+                        self.websocket.add_topics(topics)
+                    except MinerException as err:
+                        # don't panic if we have more topics than available sockets
+                        # but still log an error
+                        logger.error(err)
+                        pass
+
                     # relink watching channel after cleanup,
                     # or stop watching it if it no longer qualifies
                     watching_channel = self.watching_channel.get_with_default(None)


### PR DESCRIPTION
websocket.add_topics throws if it is given more than 400 topics (8 websockets * 50 topics per ws). 
The current Lost Ark campaign has more valid channels than this and would cause the client to instantly freeze/crash on startup due to the "Maximum topics limit has been reached" exception. 
This PR simply catches and ignores the exception.