### PR TITLE
Added Dockerfile to enable permanent deployment onto a server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.9-bullseye
+
+# Install xvfb - a virtual display for the GUI to display to
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install xvfb -y
+
+RUN git clone https://github.com/DevilXD/TwitchDropsMiner.git
+WORKDIR /TwitchDropsMiner/
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Execute every command with the virtual display active
+ENTRYPOINT ["xvfb-run"]
+CMD ["timeout", "30m", "python", "main.py"]
+
+# Example command to build:
+# docker build -t twitch_drops_miner .
+
+# Suggested command to run:
+# docker run -it --init --restart=always -v ./cookies.jar:/TwitchDropsMiner/cookies.jar -v ./settings.json:/TwitchDropsMiner/settings.json:ro twitch_drops_miner


### PR DESCRIPTION
I've added a Dockerfile, which allows the program to be run on a headless server.
This is very much a "Docker is a very big hammer and with enough force every application can be a nail" kind of approach, but it works.

We redirect the GUI to a virtual display, where it can then be comfortably ignored in peace.
As we have no liveliness check, we simply kill and restart the entire application every 30 minutes.

`settings.json` and `cookies.jar` are linked into the container.

The Dockerfile contains comments with the suggested commands to build & launch the container.

The people of #17 will be happy about this.