### PR TITLE
Fixed unclosed file descriptor

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1779,13 +1779,14 @@ class GUIManager:
         # withdraw immediately to prevent the window from flashing
         self._root.withdraw()
         # root.resizable(False, True)
-        root.iconphoto(  # window icon
-            True,
-            PhotoImage(
-                master=root,
-                image=Image_module.open(resource_path("pickaxe.ico")),
+        with Image_module.open(resource_path("pickaxe.ico")) as image:
+            root.iconphoto(  # window icon
+                True,
+                PhotoImage(
+                    master=root,
+                    image=image,
+                )
             )
-        )
         root.title(WINDOW_TITLE)  # window title
         root.bind_all("<KeyPress-Escape>", self.unfocus)  # pressing ESC unfocuses selection
         # Image cache for displaying images

--- a/main.py
+++ b/main.py
@@ -95,9 +95,10 @@ if __name__ == "__main__":
     root = tk.Tk()
     root.overrideredirect(True)
     root.withdraw()
-    root.iconphoto(
-        True, PhotoImage(master=root, image=Image_module.open(resource_path("pickaxe.ico")))
-    )
+    with Image_module.open(resource_path("pickaxe.ico")) as image:
+        root.iconphoto(
+            True, PhotoImage(master=root, image=image)
+        )
     root.update()
     parser = Parser(
         SELF_PATH.name,


### PR DESCRIPTION
The icon file descriptor was not closed properly after opening, leading to a `ResourceWarning: unclosed file <_io.BufferedReader name='pickaxe.ico'>` warning.