### PR TITLE
fixing error when running setup_env.bat

### DIFF
--- a/setup_env.bat
+++ b/setup_env.bat
@@ -12,6 +12,7 @@ if not exist "%dirpath%\env" (
 )
 echo:
 echo Installing requirements.txt...
+"%dirpath%\env\scripts\python" -m pip install --upgrade pip
 "%dirpath%\env\scripts\pip" install wheel
 "%dirpath%\env\scripts\pip" install -r "%dirpath%\requirements.txt"
 goto DONE


### PR DESCRIPTION
Fixing default pip version of venv may not meet the requirement of cryptography
Reason: In some case,  venv will use the version of pip that comes with python version instead of the latest version installed. Which means if I have an old python version but update pip to latest version via ```python -m pip install --upgrade pip```,  it still copy old version of pip when initializing venv and it caused fails to install cryptography.