### PR TITLE
New pystray

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -84,7 +84,7 @@ class ImageCache:
         return datetime.now(timezone.utc) + self.LIFETIME
 
     def _hash(self, image: Image) -> ImageHash:
-        pixel_data = list(image.resize((10, 10), Image_module.ANTIALIAS).convert('L').getdata())
+        pixel_data = list(image.resize((10, 10), Image_module.LANCZOS).convert('L').getdata())
         avg_pixel = sum(pixel_data) / len(pixel_data)
         bits = ''.join('1' if px >= avg_pixel else '0' for px in pixel_data)
         return ImageHash(f"{int(bits, 2):x}.png")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 aiohttp>2.0,<4.0
 Pillow<10.0
-# TODO: switch back to a stable pystray release when a version newer than v0.19.4 is out
-pystray@git+https://github.com/moses-palmer/pystray.git@903836104f8b1a2979f4fa5a333870ef7b075992
+pystray
 PyGObject; sys_platform == "linux" # required for better system tray support on Linux
 # selenium-wire
 # undetected-chromedriver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>2.0,<4.0
-Pillow<10.0
+Pillow
 pystray
 PyGObject; sys_platform == "linux" # required for better system tray support on Linux
 # selenium-wire


### PR DESCRIPTION
This allows `pystray` in version `0.19.5` to be installed, which supposedly should work correctly now, without having to be pinned.

Updating `pystray` also needs the newest Pillow, so I brought it up to date as well.

@guihkx Please review this from your side, IIRC it's just a matter of `0.19.4` not having the particular pinned commit changes in it, and this new official `0.19.5` has them.

Diff: https://github.com/moses-palmer/pystray/compare/903836104f8b1a2979f4fa5a333870ef7b075992..master