### PR TITLE
Linux/PyInstaller: Exclude unneeded libraries

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -76,6 +76,15 @@ a = Analysis(
     win_private_assemblies=False,
     win_no_prefer_redirects=False,
 )
+
+# Exclude unneeded Linux libraries
+excluded_binaries = [
+    "libicudata.so.66",
+    "libicuuc.so.66",
+    "librsvg-2.so.2"
+]
+a.binaries = [b for b in a.binaries if b[0] not in excluded_binaries]
+
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,


### PR DESCRIPTION
Excluding these Linux libraries doesn't seem to cause any side-effects at runtime (they're also not present in the AppImage).

And the benefit of this, is a reduction of 15 MiB in the final size of the Linux binary, which should also slightly reduce the app's startup time (but don't quote me on that). :)