### PR TITLE
CI/Linux: Build AppImage on Ubuntu 22.04 (Python 3.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
   linux-appimage:
     name: Linux (AppImage)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -155,12 +155,6 @@ jobs:
         run: |
           echo "app_version=$(python3 -c 'from version import __version__ as v; print(v)')" >> "${GITHUB_OUTPUT}"
           echo "sha_short=$(git rev-parse --short HEAD)" >> "${GITHUB_OUTPUT}"
-
-      # Ensure Python version
-      # - name: Set up Python
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{env.PYTHON_VERSION}}
 
       - name: Append git revision to project version
         run: |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Every ~60 seconds, the application sends a "minute watched" event to the channel
 
 - The Linux app is built and distributed using two distinct portable-executable formats: [AppImage](https://appimage.org/) and [PyInstaller](https://pyinstaller.org/).
 - There are no major differences between the two formats, but if you're looking for a recommendation, use the AppImage.
-- The Linux app should work out of the box on any modern distribution (as long as it has `glibc>=2.31` and a working display server).
+- The Linux app should work out of the box on any modern distribution, as long as it has `glibc>=2.31` (PyInstaller package) or `glibc>=2.35` (AppImage package), plus a working display server.
 - Every feature of the app is expected to work on Linux just as well as it does on Windows. If you find something that's broken, please [open a new issue](https://github.com/DevilXD/TwitchDropsMiner/issues/new).
 - The size of the Linux app is significantly larger than the Windows app due to the inclusion of the `gtk3` library (and its dependencies), which is required for proper system tray/notifications support.
 - As an alternative to the native Linux app, you can run the Windows app via [Wine](https://www.winehq.org/) instead. It works really well!

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -39,11 +39,11 @@ AppDir:
   apt:
     arch: amd64
     sources:
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-backports main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-security main universe
-        key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-backports main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-security main universe
+        key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C
 
     include:
       - gir1.2-appindicator3-0.1
@@ -128,13 +128,11 @@ AppDir:
     env:
       PATH: '${APPDIR}/usr/bin:${PATH}'
       PYTHONHOME: '${APPDIR}/usr'
-      PYTHONPATH: '${APPDIR}/usr/lib/python3.8/tkinter:${APPDIR}/usr/lib/python3.8/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/lib/python3.10/tkinter:${APPDIR}/usr/lib/python3.10/site-packages'
       APPDIR_LIBRARY_PATH: '${APPDIR}/usr/lib:${APPDIR}/usr/lib/x86_64-linux-gnu:${APPDIR}/lib/x86_64-linux-gnu'
       TCL_LIBRARY: '${APPDIR}/usr/share/tcltk/tcl8.6'
       TK_LIBRARY: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
       TKPATH: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
-      # Remove the line below if using Python 3.10+.
-      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.8/site-packages/certifi/cacert.pem'
       # The app seems to have problems running on Wayland at the moment.
       # See: https://github.com/DevilXD/TwitchDropsMiner/issues/321
       GDK_BACKEND: x11

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -24,6 +24,8 @@ script:
 
   # Install requirements.
   - python3 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR" -r "$SOURCE_DIR/../requirements.txt" certifi
+  # Generate byte-code files beforehand, for slightly faster app startup.
+  - python3 -m compileall "$TARGET_APPDIR/usr/src/"*.py
 
 AppDir:
   app_info:


### PR DESCRIPTION
Ubuntu 20.04 only has Python 3.8, and because the `truststore` dependency requires at least Python 3.10, the AppImage package would need to bundle CA certificates from `certifi` to make HTTPS requests work at all, which is quite an ugly workaround.
    
Unfortunately, as a side effect, building on Ubuntu 22.04 increases the minimum required version of `glibc` from 2.31 to 2.35.

Closes #421