### PR TITLE
Feat: add option to prioritize drops ending soonest

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1456,6 +1456,7 @@ class _SettingsVars(TypedDict):
     proxy: StringVar
     autostart: IntVar
     priority_only: IntVar
+    priority_by_time: IntVar
     tray_notifications: IntVar
 
 
@@ -1471,6 +1472,7 @@ class SettingsPanel:
             "tray": IntVar(master, self._settings.autostart_tray),
             "autostart": IntVar(master, self._settings.autostart),
             "priority_only": IntVar(master, self._settings.priority_only),
+            "priority_by_time": IntVar(master, self._settings.priority_by_time),
             "tray_notifications": IntVar(master, self._settings.tray_notifications),
         }
         master.rowconfigure(0, weight=1)
@@ -1527,6 +1529,12 @@ class SettingsPanel:
         ).grid(column=0, row=(irow := irow + 1), sticky="e")
         ttk.Checkbutton(
             checkboxes_frame, variable=self._vars["priority_only"], command=self.priority_only
+        ).grid(column=1, row=irow, sticky="w")
+        ttk.Label(
+            checkboxes_frame, text=_("gui", "settings", "general", "priority_by_time")
+        ).grid(column=0, row=(irow := irow + 1), sticky="e")
+        ttk.Checkbutton(
+            checkboxes_frame, variable=self._vars["priority_by_time"], command=self.priority_by_time
         ).grid(column=1, row=irow, sticky="w")
         # proxy frame
         proxy_frame = ttk.Frame(center_frame2)
@@ -1739,6 +1747,9 @@ class SettingsPanel:
 
     def priority_only(self) -> None:
         self._settings.priority_only = bool(self._vars["priority_only"].get())
+
+    def priority_by_time(self) -> None:
+        self._settings.priority_by_time = bool(self._vars["priority_by_time"].get())
 
     def exclude_add(self) -> None:
         game_name: str = self._exclude_entry.get()
@@ -2257,6 +2268,7 @@ if __name__ == "__main__":
                 autostart=False,
                 language="English",
                 priority_only=False,
+                priority_by_time=False,
                 autostart_tray=False,
                 exclude={"Lit Game"},
             )

--- a/settings.py
+++ b/settings.py
@@ -18,6 +18,7 @@ class SettingsFile(TypedDict):
     exclude: set[str]
     priority: list[str]
     priority_only: bool
+    priority_by_time: bool
     autostart_tray: bool
     connection_quality: int
     tray_notifications: bool
@@ -29,6 +30,7 @@ default_settings: SettingsFile = {
     "exclude": set(),
     "autostart": False,
     "priority_only": True,
+    "priority_by_time": False,
     "autostart_tray": False,
     "connection_quality": 1,
     "language": DEFAULT_LANG,
@@ -52,6 +54,7 @@ class Settings:
     exclude: set[str]
     priority: list[str]
     priority_only: bool
+    priority_by_time: bool
     autostart_tray: bool
     connection_quality: int
     tray_notifications: bool

--- a/translate.py
+++ b/translate.py
@@ -166,6 +166,7 @@ class GUISettingsGeneral(TypedDict):
     tray: str
     tray_notifications: str
     priority_only: str
+    priority_by_time: str
     proxy: str
 
 
@@ -363,6 +364,7 @@ default_translation: Translation = {
                 "tray": "Autostart into tray: ",
                 "tray_notifications": "Tray notifications: ",
                 "priority_only": "Priority Only: ",
+                "priority_by_time": "Prioritize campaigns by end date: ",
                 "proxy": "Proxy (requires restart):",
             },
             "game_name": "Game name",


### PR DESCRIPTION
Personally, been using this for months and thought others might appreciate it.

This maximizes the amount of potential drops by focusing on drops ending soonest.
It still takes into account user's priority list and mines those drops first before moving onto any drops that aren't prioritized. 

<img width="380" alt="Screenshot 2024-02-10 at 6 49 14 PM" src="https://github.com/DevilXD/TwitchDropsMiner/assets/3268576/e1dc5fb6-7900-4587-97f2-f8d0c2fbb385">

Note: the priority list's order doesnt matter when this setting is turned on

<img width="396" alt="Screenshot 2024-02-10 at 6 49 23 PM" src="https://github.com/DevilXD/TwitchDropsMiner/assets/3268576/4bf745ce-45f6-465c-8b78-27a624f5bee2">

See that Halo's campaign is mining first because these campaigns are often very short so this is top priority to mine before it ends. You can see that Rainbow Six Siege will be mined next as its campaigns ends after Halo's. We will mine this campaign so we don't miss it by mining something else. 

I hardly miss any drops from games in my Priority list this way because we focus on mining games that will end soon rather than mining a game that we might have a whole month to get too.