### PR TITLE
Fix building of Linux AppImage / automated uploads to the Releases page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           echo "date_now=$(date --rfc-3339=seconds)" >> "${GITHUB_OUTPUT}"
 
       - name: Download build artifacts from previous jobs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.9,<4.0
 Pillow
 pystray
-PyGObject; sys_platform == "linux" # required for better system tray support on Linux
+PyGObject<3.47; sys_platform == "linux" # required for better system tray support on Linux
 
 # environment-dependent dependencies
 pywin32; sys_platform == "win32"


### PR DESCRIPTION
Two commits:

- **CI: Update `actions/download-artifact` to `v4`**:
  This version bump is now needed because of changes from commit 7e2c233, which ended up breaking automated binaries uploads to the Releases page.

- **Linux: Pin `PyGObject` version to `<3.47`**:
  This fixes the broken `Linux (AppImage)` CI job.

  PyGObject 3.47 has dropped setuptools in favor of meson-python, which isn't a problem per se, but they also require meson 0.63.3, which we don't currently have in the repositories of Ubuntu 20.04, which is the oldest (yet supported) version we use to build our AppImage package, in order to increase compatibility with as much Linux distros as possible.

  And since there's no real, compelling reason to upgrade to the latest version of PyGObject right now, let's just pin it to version `<3.46`, until we eventually upgrade the Ubuntu version we use for CI.