### PR TITLE
On channel watch error, set channel offline and try another

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -397,5 +397,6 @@ class Channel:
             async with self._twitch.request("HEAD", stream_chunk_url) as head_response:
                 return head_response.status == 200
         except aiohttp.InvalidURL as exc:
-            # Temporarily log the entire response into the output
-            raise MinerException(available_chunks) from exc
+            return False
+            ## Temporarily log the entire response into the output
+            #raise MinerException(available_chunks) from exc

--- a/twitch.py
+++ b/twitch.py
@@ -888,6 +888,9 @@ class Twitch:
             succeeded: bool = await channel.send_watch()
             if not succeeded:
                 logger.log(CALL, f"Watch requested failed for channel: {channel.name}")
+                logger.info(f"Failed to watch {channel.name} so marking as offline...")
+                channel.set_offline()
+                continue
             elif not self.gui.progress.is_counting():
                 # If the previous update was more than 60s ago, and the progress tracker
                 # isn't counting down anymore, that means Twitch has temporarily


### PR DESCRIPTION
Basically the title.

I had an issue where 1 channel `"channel":"multiversus","channel_id":735931830` was causing me issues due to ```"error":"Content+Restricted+In+Region","error_code":"content_geoblocked","type":"error"``` and the whole app would just stop...

Bit of a hack as this will keep trying channels until it finds no more, but is that such a bad thing?