### PR TITLE
Windows: Enable DPI awareness

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,6 +83,10 @@ if __name__ == "__main__":
                 return logging.INFO
             return logging.NOTSET
 
+    if sys.platform == "win32":
+        from ctypes import windll
+        windll.shcore.SetProcessDpiAwareness(1)
+
     # handle input parameters
     # NOTE: parser output is shown via message box
     # we also need a dummy invisible window for the parser


### PR DESCRIPTION
I'm not sure if this is the best place to do this (or even the correct way to do this), but this does fix blurry fonts on Windows on displays with scaling factors higher than 100%.

Before (125% scaling factor):

![blurry](https://github.com/user-attachments/assets/6a89298a-8566-43ed-bb63-c779095e2d6a)

After (125% scaling factor):

![sharp](https://github.com/user-attachments/assets/b6fb7564-a25e-4f6d-8a6c-bcdf2a0f4695)
