### PR TITLE
Remove Python version check for `truststore`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ PyGObject; sys_platform == "linux"  # required for better system tray support on
 
 # environment-dependent dependencies
 pywin32; sys_platform == "win32"
-truststore; python_version >= "3.10"
+truststore


### PR DESCRIPTION
This follows what was done in commit 2f9467497c2ff3fe89d27ebaf77862bcb770b967.