### PR TITLE
Linux: Pin `PyGObject` version to `<3.51`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.9,<4.0
 Pillow
 pystray
-PyGObject; sys_platform == "linux"  # required for better system tray support on Linux
+PyGObject<3.51; sys_platform == "linux"  # required for better system tray support on Linux
 
 # environment-dependent dependencies
 pywin32; sys_platform == "win32"


### PR DESCRIPTION
PyGObject 3.51 (and newer) [now requires `girepository-2.0`](https://gitlab.gnome.org/GNOME/pygobject/-/blob/d29f4e65faabf2ba6892a976a0fdfcb2cc3031f7/NEWS#L4-5) as a build dependency, which is a version we cannot easily install in the Ubuntu version we use in CI/CD, so the build fails:

```sh
$ python3 -m pip install -r requirements.txt
[ ... ]
Collecting PyGObject (from -r requirements.txt (line 4))
  Downloading pygobject-3.52.3.tar.gz (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 45.4 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [216 lines of output]
      + meson setup /tmp/pip-install-nayte7bo/pygobject_097c5326983b4ca690e238e49ba4b29c /tmp/pip-install-nayte7bo/pygobject_097c5326983b4ca690e238e49ba4b29c/.mesonpy-sp71efmg -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md -Dtests=false -Dwheel=true --wrap-mode=nofallback --native-file=/tmp/pip-install-nayte7bo/pygobject_097c5326983b4ca690e238e49ba4b29c/.mesonpy-sp71efmg/meson-python-native-file.ini The Meson build system Version: 1.7.0 Source dir: /tmp/pip-install-nayte7bo/pygobject_097c5326983b4ca690e238e49ba4b29c Build dir: /tmp/pip-install-nayte7bo/pygobject_097c5326983b4ca690e238e49ba4b29c/.mesonpy-sp71efmg Build type: native build Project name: pygobject Project version: 3.52.3 C compiler for the host machine: cc (gcc 9.4.0 "cc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0") C linker for the host machine: cc ld.bfd 2.34 Host machine cpu family: x86_64 Host machine cpu: x86_64 Program python3 found: YES (/opt/hostedtoolcache/Python/3.10.16/x64/bin/python3) Found pkg-config: YES (/usr/bin/pkg-config) 1.6.3 Run-time dependency python found: YES 3.10 Found CMake: /usr/local/bin/cmake (3.31.6) Run-time dependency girepository-2.0 found: NO (tried pkgconfig and cmake) Not looking for a fallback subproject for the dependency girepository-2.0 because: Use of fallback dependencies is disabled.

      ../meson.build:31:9: ERROR: Dependency 'girepository-2.0' is required but not found.
```

Unfortunately, `girepository-2.0` is only available in Ubuntu 24.10, a version we can't easily use in GitHub Actions. But even if could, doing so would also needlessly bump the minimum glibc version requirement for Linux users, making TDM much less portable.

So, for now, let's pin `PyGObject` to `<3.51`.
