### PR TITLE
CI/Linux: Update PyInstaller builder to run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
   linux-pyinstaller:
     name: Linux (PyInstaller)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - validate
 
@@ -121,7 +121,7 @@ jobs:
         run: |
           sed -ri "s/^__version__\s*=\s*\"[^\"]+/\0.${{steps.vars.outputs.sha_short}}/" version.py
 
-      # NOTE: We're only use a custom version of Python here because truststore requires at least Python 3.10, but Ubuntu 20.04 has Python 3.8.
+      # Ensure Python version
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -141,7 +141,7 @@ jobs:
         run: |
           python3 -m pip install pyinstaller
 
-      # NOTE: Remove this step if/once libxft gets updated to 2.3.5 or newer on Ubuntu 20.04, which currently has 2.3.3.
+      # NOTE: Remove this step if/once libxft gets updated to 2.3.5 or newer on Ubuntu 22.04, which currently has 2.3.4.
       - name: Build a recent version of libXft
         run: |
           mkdir -p /tmp/libXft

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every several seconds, the application pretends to watch a particular stream by 
 
 - The Linux app is built and distributed using two distinct portable-executable formats: [AppImage](https://appimage.org/) and [PyInstaller](https://pyinstaller.org/).
 - There are no major differences between the two formats, but if you're looking for a recommendation, use the AppImage.
-- The Linux app should work out of the box on any modern distribution, as long as it has `glibc>=2.31` (PyInstaller package) or `glibc>=2.35` (AppImage package), plus a working display server.
+- The Linux app should work out of the box on any modern distribution, as long as it has `glibc>=2.35`, plus a working display server.
 - Every feature of the app is expected to work on Linux just as well as it does on Windows. If you find something that's broken, please [open a new issue](https://github.com/DevilXD/TwitchDropsMiner/issues/new).
 - The size of the Linux app is significantly larger than the Windows app due to the inclusion of the `gtk3` library (and its dependencies), which is required for proper system tray/notifications support.
 - As an alternative to the native Linux app, you can run the Windows app via [Wine](https://www.winehq.org/) instead. It works really well!

--- a/build.spec
+++ b/build.spec
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 import platform
+import fnmatch
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
@@ -91,13 +92,16 @@ a = Analysis(
     win_no_prefer_redirects=False,
 )
 
-# Exclude unneeded Linux libraries
+# Exclude unneeded Linux libraries (supports globbing)
 excluded_binaries = [
-    "libicudata.so.66",
-    "libicuuc.so.66",
-    "librsvg-2.so.2"
+    "libicudata.so.*",
+    "libicuuc.so.*",
+    "librsvg-*.so.*"
 ]
-a.binaries = [b for b in a.binaries if b[0] not in excluded_binaries]
+a.binaries = [
+    b for b in a.binaries
+    if not any(fnmatch.fnmatch(b[0], pattern) for pattern in excluded_binaries)
+]
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(


### PR DESCRIPTION
The Ubuntu 20.04 runner image is expected to be removed from GitHub Actions on April 1st, 2025.

Source: https://github.com/actions/runner-images/issues/11101