### PR TITLE
Linux/AppImage: Manually download the runtime to fix build error

### DIFF
--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -9,6 +9,11 @@ script:
   - mkdir -p "$BUILD_DIR" "$TARGET_APPDIR"
   - cd "$BUILD_DIR"
 
+  # TODO: Remove this if/when appimage-builder releases a version newer than 1.1.0.
+  #       This is a workaround for: https://github.com/AppImageCrafters/appimage-builder/issues/375
+  - mkdir -p "$BUILD_DIR/prime"
+  - curl -L https://github.com/AppImage/AppImageKit/releases/download/continuous/obsolete-runtime-x86_64 -o "$BUILD_DIR/prime/runtime-x86_64"
+
   # Build a recent version of libXft first. This fixes an issue where the app won't start with libXft 2.3.3 if an emoji font is installed on the system.
   - curl -L https://xorg.freedesktop.org/releases/individual/lib/libXft-2.3.8.tar.xz -o libXft.tar.xz
   - tar xvf libXft.tar.xz


### PR DESCRIPTION
This manually downloads the old AppImage runtime (now marked as obsolete), to prevent appimage-builder v1.1.0 from failing to make the AppImage.

The download URL appimage-builder v1.1.0 uses for the AppImage runtime is hardcoded into the tool, and unfortunately it's been recently removed, so this is merely a workaround, until hopefully a future appimage-builder release fixes this.

See: https://github.com/AppImageCrafters/appimage-builder/issues/375