### PR TITLE
Linux/AppImage: Update `appimage-builder` to git version, plus misc. improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
 
       - name: Create AppImage
         env:
+          ARCH: x86_64
           APP_VERSION: ${{steps.vars.outputs.app_version}}.${{steps.vars.outputs.sha_short}}
           PYTHON_VERSION: ${{env.PYTHON_VERSION}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,18 +200,17 @@ jobs:
           sudo apt update
           sudo apt install libgirepository1.0-dev gir1.2-ayatanaappindicator3-0.1 libayatana-appindicator3-1 python3-testresources
 
-      - name: Download AppImage Builder
+      - name: Install appimage-builder
         run: |
-          curl -L https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage -o appimage-builder
-          chmod +x appimage-builder
+          # TODO: Switch to a stable release if/when a version newer than 1.1.0 is released.
+          python3 -m pip install git+https://github.com/AppImageCrafters/appimage-builder.git@e995e8edcc227d14524cf39f9824c238f9435a22
 
       - name: Create AppImage
         env:
-          APPIMAGE_EXTRACT_AND_RUN: 1
           APP_VERSION: ${{steps.vars.outputs.app_version}}.${{steps.vars.outputs.sha_short}}
           PYTHON_VERSION: ${{env.PYTHON_VERSION}}
         run: |
-          ./appimage-builder --recipe appimage/AppImageBuilder.yml
+          appimage-builder --recipe appimage/AppImageBuilder.yml
 
       - name: Create release folder
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install libgirepository1.0-dev gir1.2-ayatanaappindicator3-0.1 libayatana-appindicator3-1 python3-testresources
+          sudo apt install libgirepository1.0-dev gir1.2-ayatanaappindicator3-0.1 libayatana-appindicator3-1
 
       - name: Install appimage-builder
         run: |

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -42,10 +42,9 @@ AppDir:
   apt:
     arch: amd64
     sources:
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-backports main universe
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-security main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-security main
         key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C
 
     include:

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -30,6 +30,9 @@ script:
   # Generate byte-code files and package them for a slightly faster app startup.
   - python3 -m compileall "$TARGET_APPDIR/usr/src/"*.py
 
+  # Recursively remove ELF debug symbols, trimming roughly 10 MB off the AppDir.
+  - find "$TARGET_APPDIR" -type f -print0 | xargs -0 file | grep -F 'not stripped' | cut -f1 -d':' | sort -V | xargs -r strip -s -v
+
 AppDir:
   app_info:
     id: io.github.devilxd.twitchdropsminer

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -131,14 +131,14 @@ AppDir:
       PATH: '${APPDIR}/usr/bin:${PATH}'
       PYTHONHOME: '${APPDIR}/usr'
       PYTHONPATH: '${APPDIR}/usr/lib/python3.10/tkinter:${APPDIR}/usr/lib/python3.10/site-packages'
-      APPDIR_LIBRARY_PATH: '${APPDIR}/usr/lib:${APPDIR}/usr/lib/x86_64-linux-gnu:${APPDIR}/lib/x86_64-linux-gnu'
+      APPDIR_LIBRARY_PATH: '${APPDIR}/usr/lib:${APPDIR}/usr/lib/{{ARCH}}-linux-gnu:${APPDIR}/lib/{{ARCH}}-linux-gnu'
       TCL_LIBRARY: '${APPDIR}/usr/share/tcltk/tcl8.6'
-      TK_LIBRARY: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
-      TKPATH: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
+      TK_LIBRARY: '${APPDIR}/usr/lib/tcltk/{{ARCH}}-linux-gnu/tk8.6'
+      TKPATH: '${APPDIR}/usr/lib/tcltk/{{ARCH}}-linux-gnu/tk8.6'
 
 AppImage:
-  arch: x86_64
-  file_name: Twitch.Drops.Miner-x86_64.AppImage
+  arch: '{{ARCH}}'
+  file_name: Twitch.Drops.Miner-{{ARCH}}.AppImage
   comp: zstd
   sign-key: None
   update-information: guess

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -9,11 +9,6 @@ script:
   - mkdir -p "$BUILD_DIR" "$TARGET_APPDIR"
   - cd "$BUILD_DIR"
 
-  # TODO: Remove this if/when appimage-builder releases a version newer than 1.1.0.
-  #       This is a workaround for: https://github.com/AppImageCrafters/appimage-builder/issues/375
-  - mkdir -p "$BUILD_DIR/prime"
-  - curl -L https://github.com/AppImage/AppImageKit/releases/download/continuous/obsolete-runtime-x86_64 -o "$BUILD_DIR/prime/runtime-x86_64"
-
   # Build a recent version of libXft first. This fixes an issue where the app won't start with libXft 2.3.3 if an emoji font is installed on the system.
   - curl -L https://xorg.freedesktop.org/releases/individual/lib/libXft-2.3.8.tar.xz -o libXft.tar.xz
   - tar xvf libXft.tar.xz
@@ -147,5 +142,6 @@ AppDir:
 AppImage:
   arch: x86_64
   file_name: Twitch.Drops.Miner-x86_64.AppImage
+  comp: zstd
   sign-key: None
   update-information: guess

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -136,9 +136,6 @@ AppDir:
       TCL_LIBRARY: '${APPDIR}/usr/share/tcltk/tcl8.6'
       TK_LIBRARY: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
       TKPATH: '${APPDIR}/usr/lib/tcltk/x86_64-linux-gnu/tk8.6'
-      # The app seems to have problems running on Wayland at the moment.
-      # See: https://github.com/DevilXD/TwitchDropsMiner/issues/321
-      GDK_BACKEND: x11
 
 AppImage:
   arch: x86_64

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -105,20 +105,33 @@ AppDir:
       - usr/bin/pydoc*
       - usr/bin/pygettext3*
       - usr/include
+      - usr/lib/binfmt.d
+      - usr/lib/blt2.5
+      - usr/lib/libBLTlite.2.5*
       # The next 2 files come from our own build of libXft, and they can be removed.
       - usr/lib/libXft.la
       - usr/lib/pkgconfig
-      - usr/lib/python3.9
+      - usr/lib/python3
+      - usr/lib/python3.11
+      - usr/lib/python3*/pydoc_data
+      - usr/lib/python3*/test
+      - usr/lib/python3*/unittest
       - usr/lib/valgrind
-      - usr/lib/*-linux-gnu/engines-1.1
+      - usr/lib/*-linux-gnu/audit
+      - usr/lib/*-linux-gnu/engines-3
+      - usr/lib/*-linux-gnu/gconv
       - usr/lib/*-linux-gnu/glib-2.0
       - usr/lib/*-linux-gnu/gtk-3.0
-      - usr/lib/*-linux-gnu/libgtk-3.0
+      - usr/lib/*-linux-gnu/libgtk-3-0
+      - usr/lib/*-linux-gnu/ossl-modules
+      - usr/sbin
       - usr/share/applications
       - usr/share/binfmts
       - usr/share/bug
       - usr/share/doc
       - usr/share/doc-base
+      - usr/share/gcc
+      - usr/share/gdb
       - usr/share/glib-2.0
       - usr/share/lintian
       - usr/share/man

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -23,10 +23,10 @@ script:
   - cp "$SOURCE_DIR/pickaxe.png" "$TARGET_APPDIR/usr/share/icons/hicolor/128x128/apps/io.github.devilxd.twitchdropsminer.png"
 
   # Create a virtual environment and install up-to-date versions of meson and ninja.
-  - python3 -m venv env && source ./env/bin/activate && python3 -m pip install meson ninja
+  - python3 -m venv env && ./env/bin/python3 -m pip install meson ninja
   # Install requirements.
-  - python3 -m pip install --ignore-installed --prefix=/usr --root="$TARGET_APPDIR" -r "$SOURCE_DIR/../requirements.txt" certifi
-  # Generate byte-code files beforehand, for slightly faster app startup.
+  - PATH="$PWD/env/bin:$PATH" python3 -m pip install --prefix=/usr --root="$TARGET_APPDIR" -r "$SOURCE_DIR/../requirements.txt"
+  # Generate byte-code files and package them for a slightly faster app startup.
   - python3 -m compileall "$TARGET_APPDIR/usr/src/"*.py
 
 AppDir:

--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -10,9 +10,10 @@ script:
   - cd "$BUILD_DIR"
 
   # Build a recent version of libXft first. This fixes an issue where the app won't start with libXft 2.3.3 if an emoji font is installed on the system.
-  - curl -L https://xorg.freedesktop.org/releases/individual/lib/libXft-2.3.8.tar.xz -o libXft.tar.xz
+  - curl -fL https://xorg.freedesktop.org/releases/individual/lib/libXft-2.3.9.tar.xz -o libXft.tar.xz
+  - sha256sum libXft.tar.xz
   - tar xvf libXft.tar.xz
-  - cd libXft-2.3.8
+  - cd libXft-*
   - ./configure --prefix="$TARGET_APPDIR/usr" --disable-static
   - make -j$(nproc)
   - make install-strip


### PR DESCRIPTION
There are quite a few changes here, but the most important one is the update of our AppImage-making tool, [appimage-builder](https://github.com/AppImageCrafters/appimage-builder), from version v1.1.0 (released in 2022), to the git version (more specifically, to commit [`e995e8e`](https://github.com/AppImageCrafters/appimage-builder/commit/e995e8edcc227d14524cf39f9824c238f9435a22)).

Even though appimage-builder is not being regularly maintained anymore, the git version still has everything we need to build an AppImage with the latest runtime changes introduced by the AppImage specification.

In short, the AppImage people now recommends switching to their new statically-linked runtime — the previous runtime required `libfuse2` to be preinstalled on the system just to launch the AppImage, which is not ideal. To make matters worse, Linux distros are slowly removing `libfuse2` from their repositories.

Two other major changes to the AppImage runtime, are the removal of the XZ compression format, and the addition of the Zstd compression format (which we now use too, and as result, launching the AppImage is much faster).

---

I know you don't use Linux (if I remember correctly), so you're probably not interested in most of these changes. But if you are, I've added a bit more detail about them in each commit message.

Thanks!