### PR TITLE
Detect OS dark mode for default value

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp>=3.9,<4.0
+darkdetect
 Pillow
 pystray
 PyGObject<3.51; sys_platform == "linux"  # required for better system tray support on Linux

--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,13 @@ from constants import SETTINGS_PATH, DEFAULT_LANG, PriorityMode
 if TYPE_CHECKING:
     from main import ParsedArgs
 
+def _detect_system_dark_mode() -> bool:
+    try:
+        import darkdetect
+        return darkdetect.isDark()
+    except Exception:
+        return False
+
 
 class SettingsFile(TypedDict):
     proxy: URL
@@ -27,7 +34,7 @@ default_settings: SettingsFile = {
     "proxy": URL(),
     "priority": [],
     "exclude": set(),
-    "dark_mode": False,
+    "dark_mode": _detect_system_dark_mode(),
     "autostart_tray": False,
     "connection_quality": 1,
     "language": DEFAULT_LANG,


### PR DESCRIPTION
When settings.json file doesn't exist yet, this will allow detecting the current dark mode setting for the OS and use that for the default. `darkdetect` works on Windows/Mac/Linux.

If you would prefer to not use darkdetect, let me know and I can come up with a version that checks Windows/Linux manually.