### PR TITLE
Fix: Correct autostart query logic for Linux

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1812,7 +1812,7 @@ class SettingsPanel:
                 return False
             with autostart_file.open('r', encoding="utf8") as file:
                 # TODO: Consider deleting the old file to avoid autostart errors
-                return self._get_self_path() not in file.read()
+                return self._get_self_path() in file.read()
 
     def update_autostart(self) -> None:
         enabled = bool(self._vars["autostart"].get())


### PR DESCRIPTION
The `_query_autostart` method in `gui.py` had inverted logic for checking the autostart status on Linux. It would return `False` when the application's path was found in the autostart file, and `True` otherwise. This caused the autostart checkbox in the settings to display an incorrect status and for the feature to not work as intended.

This commit corrects the logic by removing the `not` operator from the check, ensuring that the method returns `True` when the path is found in the autostart file, and `False` otherwise.