### PR TITLE
Update Traditional Chinese translation

### DIFF
--- a/lang/繁體中文.json
+++ b/lang/繁體中文.json
@@ -138,6 +138,13 @@
                 "priority_mode": "掉寶模式：",
                 "proxy": "代理伺服器（需要重新啟動）："
             },
+            "advanced": {
+                "name": "進階設定",
+                "warning": "警告！",
+                "warning_text": "啟用以下選項可能會導致應用程式運作異常。\n如果您遇到任何問題，請先停用以下所有選項。",
+                "enable_badges_emotes": "啟用對獲取徽章和表情掉寶的不完整支援：",
+                "available_drops_check": "啟用額外的掉寶可用性檢查："
+            },
             "priority_modes": {
                 "priority_only": "僅參與優先掉寶遊戲",
                 "ending_soonest": "優先觀看即將結束的掉寶活動",


### PR DESCRIPTION
Updates and adjustments for Traditional Chinese l10n, including:
- commit f3ebd7a and ce3a972 adjust existing `help` and `unexpected_content` to make them looks fine and fluent
- commit ebbda3a covers the new advanced settings

before f3ebd7a:
<img width="1037" height="720" alt="image" src="https://github.com/user-attachments/assets/c4960b03-8933-4633-93ea-6bffc2e5e44c" />

after f3ebd7a:
<img width="968" height="720" alt="image" src="https://github.com/user-attachments/assets/a89c9f5e-7d7b-4fe1-b2f2-0434d9a84862" />

before ebbda3a:
<img width="1037" height="720" alt="image" src="https://github.com/user-attachments/assets/f6d1218e-a698-4ea9-8ea3-717356f628dc" />

after ebbda3a:
<img width="968" height="720" alt="image" src="https://github.com/user-attachments/assets/07f03c08-8215-40b4-a94b-614af639fa89" />
