### PR TITLE
Fix spade URL extraction for new Twitch format (/track)

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -290,7 +290,7 @@ class Channel:
         )
         # NOTE: "beacon" appears in the file first, so it's the most likely one to be matched.
         SPADE_PATTERN: str = (
-            r'"(?:beacon|spade)_?url": ?"(https://[.\w\-/]+\.ts(?:\?allow_stream=true)?)"'
+            r'"(?:beacon|spade)_?url": ?"(https://[.\w\-/]+(?:\.ts(?:\?allow_stream=true)?|/track))"'
         )
         async with self._twitch.request("GET", self.url) as response1:
             streamer_html: str = await response1.text(encoding="utf8")


### PR DESCRIPTION
## Summary
- Twitch changed `beacon_url`/`spade_url` from `video-edge-*.ts` endpoints to `spade.twitch.tv/track` / `beacon.twitch.tv/track`
- The existing regex requires `.ts` at the end of the URL, which no longer matches
- Updated `SPADE_PATTERN` to accept both `.ts` and `/track` URL formats

## Verification
Tested on a live Twitch channel (quickybaby). Before the fix, `get_spade_url()` throws `MinerException: Error while spade_url extraction: step #2` on every channel switch. After the fix, the spade URL is correctly extracted and watching works normally.

Fixes #981, fixes #904