### PR TITLE
Fix multiple crash-causing bugs (GQL retry, spade URL, SSL, CurrentDrop)

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -465,11 +465,20 @@ class Channel:
         if self._stream is None:
             return False
         if self._spade_url is None:
-            self._spade_url = await self.get_spade_url()
+            try:
+                self._spade_url = await self.get_spade_url()
+            except MinerException:
+                logger.error(f"Failed to extract spade URL for channel: {self._login}")
+                return False
         try:
             async with self._twitch.request(
                 "POST", self._spade_url, data=self._stream._spade_payload
             ) as response:
-                return response.status == 204
+                if response.status == 204:
+                    return True
+                # spade URL may have gone stale - clear it so it's re-fetched next time
+                self._spade_url = None
+                return False
         except RequestException:
+            self._spade_url = None
             return False

--- a/main.py
+++ b/main.py
@@ -18,8 +18,15 @@ if __name__ == "__main__":
     from tkinter import messagebox
     from typing import NoReturn, TYPE_CHECKING
 
+    import ssl
     import truststore
-    truststore.inject_into_ssl()
+    try:
+        truststore.inject_into_ssl()
+    except ssl.SSLError:
+        # System certificate store contains an invalid certificate.
+        # Fall back to Python's default certificate handling.
+        # See: https://github.com/python/cpython/issues/79846
+        pass
 
     from translate import _
     from twitch import Twitch

--- a/twitch.py
+++ b/twitch.py
@@ -910,10 +910,11 @@ class Twitch:
                             {"channelID": str(channel.id)}
                         )
                     )
+                    current_user = context["data"]["currentUser"]
                     drop_data: JsonType | None = (
-                        context["data"]["currentUser"]["dropCurrentSession"]
+                        current_user["dropCurrentSession"] if current_user else None
                     )
-                except GQLException:
+                except (GQLException, KeyError, TypeError):
                     drop_data = None
                 if drop_data is not None:
                     gql_drop: TimedDrop | None = self._drops.get(drop_data["dropID"])
@@ -1311,8 +1312,8 @@ class Twitch:
                             if (
                                 single_retry
                                 and error_dict["message"] in (
-                                    "service error"
-                                    "PersistedQueryNotFound"
+                                    "service error",
+                                    "PersistedQueryNotFound",
                                 )
                             ):
                                 logger.error(
@@ -1354,7 +1355,7 @@ class Twitch:
             else:
                 return orig_response
             await asyncio.sleep(delay)
-        raise RuntimeError("Retry loop was broken")
+        raise GQLException("GQL request failed after exhausting all retries")
 
     def _merge_data(self, primary_data: JsonType, secondary_data: JsonType) -> JsonType:
         merged = {}


### PR DESCRIPTION
## Summary

This PR fixes 5 crash-causing bugs, the most critical being a missing comma that completely breaks GQL error retry logic.

### 1. Fix missing comma in GQL error handling tuple (fixes #415, #417, #727, #855, #976)

The strings `"service error"` and `"PersistedQueryNotFound"` were implicitly concatenated due to a missing comma, producing a single string `"service errorPersistedQueryNotFound"` that never matches any actual error message. This caused the retry logic to never trigger for these errors, resulting in `GQLException` crashes instead of graceful retries.

**Before:** `("service error" "PersistedQueryNotFound")` → tuple with ONE element `"service errorPersistedQueryNotFound"`
**After:** `("service error", "PersistedQueryNotFound",)` → tuple with TWO elements that match correctly

### 2. Fix spade URL extraction crash in send_watch (fixes #904)

`get_spade_url()` can raise `MinerException` when Twitch changes their page structure. This exception was unhandled in `send_watch()`, propagating up to `_watch_loop` (a critical task) and terminating the entire application. Now catches the exception and returns `False`, allowing the watch loop to continue. Also clears stale spade URLs on non-204 responses so they get re-fetched on the next attempt.

### 3. Fix SSL truststore crash on startup (fixes #642)

`truststore.inject_into_ssl()` can crash with `ssl.SSLError` if the system certificate store contains an invalid certificate (common on Windows). This prevented the application from starting at all. Now catches `SSLError` and falls back to Python's default certificate handling. See [cpython#79846](https://github.com/python/cpython/issues/79846).

### 4. Fix TypeError crash in CurrentDrop GQL handling

If `currentUser` is `None` in the GQL response (e.g. auth session expired), `None["dropCurrentSession"]` raises `TypeError` which was not caught by the existing `except GQLException` clause. Now checks for `None` before access and catches `KeyError`/`TypeError` as well.

### 5. Replace uninformative RuntimeError with GQLException

When the GQL retry loop exhausts all retries, it raised a generic `RuntimeError("Retry loop was broken")`. Now raises `GQLException` with a descriptive message, which is properly handled by existing error handling code upstream.

## Test plan

- All changes are defensive fixes (error handling improvements)
- Fix 1 can be verified by Python REPL: `"service error" in ("service error", "PersistedQueryNotFound")` → `True` vs the old `"service error" in ("service error" "PersistedQueryNotFound",)` → `False`