### PR TITLE
Add startup update check via GitHub API

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -107,6 +107,9 @@ CACHE_PATH = Path(WORKING_DIR, "cache")
 CACHE_DB = Path(CACHE_PATH, "mapping.json")
 COOKIES_PATH = Path(WORKING_DIR, "cookies.jar")
 SETTINGS_PATH = Path(WORKING_DIR, "settings.json")
+# GitHub
+GITHUB_REPO_API = "https://api.github.com/repos/DevilXD/TwitchDropsMiner"
+GITHUB_RELEASES_URL = "https://github.com/DevilXD/TwitchDropsMiner/releases/tag/dev-build"
 # Typing
 JsonType = Dict[str, Any]
 URLType = NewType("URLType", str)

--- a/gui.py
+++ b/gui.py
@@ -47,6 +47,7 @@ from constants import (
     MAX_WEBSOCKETS,
     WS_TOPICS_LIMIT,
     OUTPUT_FORMATTER,
+    GITHUB_RELEASES_URL,
     State,
     PriorityMode,
 )
@@ -2141,6 +2142,18 @@ class HelpTab:
             link="https://www.twitch.tv/drops/campaigns",
             text=_("gui", "help", "links", "campaigns"),
         ).grid(column=0, row=1, sticky="nsew")
+        # Update check
+        update_frame = ttk.LabelFrame(center_frame, padding=(4, 0, 4, 4), text="Updates")
+        update_frame.grid(column=0, row=(irow := irow + 1), sticky="nsew", padx=2)
+        update_frame.columnconfigure(1, weight=1)
+        self._update_button = ttk.Button(
+            update_frame, text="Check for Updates", command=self._check_updates
+        )
+        self._update_button.grid(column=0, row=0, sticky="w", padx=(0, 8))
+        self._update_label = ttk.Label(update_frame, text="")
+        self._update_label.grid(column=1, row=0, sticky="w")
+        self._update_link: LinkLabel | None = None
+        self._update_link_frame = update_frame
         # How It Works
         howitworks = ttk.LabelFrame(
             center_frame, padding=(4, 0, 4, 4), text=_("gui", "help", "how_it_works")
@@ -2156,6 +2169,30 @@ class HelpTab:
         ttk.Label(
             getstarted, text=_("gui", "help", "getting_started_text"), wraplength=self.WIDTH
         ).grid(sticky="nsew")
+
+    def _check_updates(self):
+        self._update_button.configure(state="disabled")
+        self._update_label.configure(text="Checking...", style="TLabel")
+        # remove previous download link if any
+        if self._update_link is not None:
+            self._update_link.destroy()
+            self._update_link = None
+
+        async def do_check():
+            update_available, message = await self._twitch.check_for_updates()
+            if update_available:
+                self._update_label.configure(text=message, style="yellow.TLabel")
+                self._update_link = LinkLabel(
+                    self._update_link_frame,
+                    link=GITHUB_RELEASES_URL,
+                    text="Download here",
+                )
+                self._update_link.grid(column=2, row=0, sticky="w", padx=(8, 0))
+            else:
+                self._update_label.configure(text=message, style="green.TLabel")
+            self._update_button.configure(state="normal")
+
+        asyncio.create_task(do_check())
 
 
 ##########################################

--- a/twitch.py
+++ b/twitch.py
@@ -18,6 +18,7 @@ from yarl import URL
 from translate import _
 from gui import GUIManager
 from channel import Channel
+from version import __version__
 from websocket import WebsocketPool
 from inventory import DropsCampaign
 from exceptions import (
@@ -48,6 +49,8 @@ from constants import (
     MAX_CHANNELS,
     GQL_OPERATIONS,
     WATCH_INTERVAL,
+    GITHUB_REPO_API,
+    GITHUB_RELEASES_URL,
     State,
     ClientType,
     PriorityMode,
@@ -557,6 +560,33 @@ class Twitch:
         """
         self.gui.save(force=force)
         self.settings.save(force=force)
+
+    async def check_for_updates(self) -> tuple[bool, str]:
+        """
+        Check GitHub for a newer version.
+
+        Returns (update_available, message) tuple.
+        """
+        try:
+            # Extract commit hash from version string (e.g., "16.dev.6b23aee" -> "6b23aee")
+            version_parts = __version__.split(".")
+            current_hash = version_parts[-1] if len(version_parts) >= 3 else None
+            session = await self.get_session()
+            async with session.get(
+                f"{GITHUB_REPO_API}/commits/master",
+                headers={"Accept": "application/vnd.github.v3+json"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status != 200:
+                    return False, "Failed to check for updates (HTTP error)"
+                data = await response.json()
+            remote_hash: str = data["sha"][:7]
+            remote_date: str = data["commit"]["committer"]["date"][:10]
+            if current_hash is not None and current_hash == remote_hash:
+                return False, "You are running the latest version."
+            return True, f"Update available ({remote_hash}, {remote_date})"
+        except Exception:
+            return False, "Failed to check for updates (network error)"
 
     def get_priority(self, channel: Channel) -> int:
         """


### PR DESCRIPTION
## Summary

Adds a **Check for Updates** button in the Help tab that queries the GitHub API for the latest commit on `master` and compares it with the current build's embedded commit hash.

**How it works:**
- Extracts the commit hash from `__version__` (e.g., `"16.dev.6b23aee"` → `"6b23aee"`)
- Fetches `GET /repos/DevilXD/TwitchDropsMiner/commits/master` from GitHub API
- Compares the 7-char short SHA
- If a newer version is found, shows a yellow notification with a "Download here" link to the releases page
- If up to date, shows a green "You are running the latest version" message

**Design decisions:**
- **Manual trigger**: User clicks the button — no automatic checks
- **Best-effort**: All exceptions are silently caught — the check never crashes the app
- **Minimal**: No new dependencies, no auto-download — just a notification with download link
- **10s timeout**: Won't block even on slow connections

This is a lightweight implementation of #127.

## Test plan

- [ ] Verify "Check for Updates" correctly detects newer/same version
- [ ] Verify the check handles GitHub API errors gracefully
- [ ] Verify the "Download here" link opens the correct releases page