### PR TITLE
Add in-place auto-update (download and restart)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -110,6 +110,8 @@ SETTINGS_PATH = Path(WORKING_DIR, "settings.json")
 # GitHub
 GITHUB_REPO_API = "https://api.github.com/repos/DevilXD/TwitchDropsMiner"
 GITHUB_RELEASES_URL = "https://github.com/DevilXD/TwitchDropsMiner/releases/tag/dev-build"
+# Update paths
+UPDATE_DIR = Path(WORKING_DIR, "update_tmp")
 # Typing
 JsonType = Dict[str, Any]
 URLType = NewType("URLType", str)

--- a/gui.py
+++ b/gui.py
@@ -2153,6 +2153,8 @@ class HelpTab:
         self._update_label = ttk.Label(update_frame, text="")
         self._update_label.grid(column=1, row=0, sticky="w")
         self._update_link: LinkLabel | None = None
+        self._update_apply_button: ttk.Button | None = None
+        self._update_download_url: str | None = None
         self._update_link_frame = update_frame
         # How It Works
         howitworks = ttk.LabelFrame(
@@ -2170,29 +2172,74 @@ class HelpTab:
             getstarted, text=_("gui", "help", "getting_started_text"), wraplength=self.WIDTH
         ).grid(sticky="nsew")
 
-    def _check_updates(self):
-        self._update_button.configure(state="disabled")
-        self._update_label.configure(text="Checking...", style="TLabel")
-        # remove previous download link if any
+    def _clear_update_widgets(self):
         if self._update_link is not None:
             self._update_link.destroy()
             self._update_link = None
+        if self._update_apply_button is not None:
+            self._update_apply_button.destroy()
+            self._update_apply_button = None
+
+    def _check_updates(self):
+        self._update_button.configure(state="disabled")
+        self._update_label.configure(text="Checking...", style="TLabel")
+        self._clear_update_widgets()
 
         async def do_check():
-            update_available, message = await self._twitch.check_for_updates()
+            update_available, message, download_url = await self._twitch.check_for_updates()
             if update_available:
                 self._update_label.configure(text=message, style="yellow.TLabel")
+                self._update_download_url = download_url
+                if download_url is not None:
+                    # Packaged build: offer in-place update
+                    self._update_apply_button = ttk.Button(
+                        self._update_link_frame,
+                        text="Update Now",
+                        command=self._apply_update,
+                    )
+                    self._update_apply_button.grid(
+                        column=2, row=0, sticky="w", padx=(8, 0)
+                    )
+                # Always show download link as fallback
                 self._update_link = LinkLabel(
                     self._update_link_frame,
                     link=GITHUB_RELEASES_URL,
-                    text="Download here",
+                    text="Download manually",
                 )
-                self._update_link.grid(column=2, row=0, sticky="w", padx=(8, 0))
+                col = 3 if download_url is not None else 2
+                self._update_link.grid(column=col, row=0, sticky="w", padx=(8, 0))
             else:
                 self._update_label.configure(text=message, style="green.TLabel")
             self._update_button.configure(state="normal")
 
         asyncio.create_task(do_check())
+
+    def _apply_update(self):
+        if self._update_download_url is None:
+            return
+        self._update_button.configure(state="disabled")
+        if self._update_apply_button is not None:
+            self._update_apply_button.configure(state="disabled")
+
+        def on_progress(msg: str):
+            self._update_label.configure(text=msg, style="TLabel")
+
+        async def do_update():
+            success = await self._twitch.download_update(
+                self._update_download_url, progress_callback=on_progress
+            )
+            if success:
+                # On Windows the batch script will restart; on Linux/macOS os.execv replaces us.
+                # If we're still here, trigger a close.
+                self._update_label.configure(text="Update applied! Closing...", style="green.TLabel")
+                await asyncio.sleep(1)
+                self._twitch.gui.close()
+            else:
+                self._update_button.configure(state="normal")
+                if self._update_apply_button is not None:
+                    self._update_apply_button.configure(state="normal")
+
+        asyncio.create_task(do_update())
 
 
 ##########################################

--- a/main.py
+++ b/main.py
@@ -18,8 +18,13 @@ if __name__ == "__main__":
     from tkinter import messagebox
     from typing import NoReturn, TYPE_CHECKING
 
+    import shutil
+    import ssl
     import truststore
-    truststore.inject_into_ssl()
+    try:
+        truststore.inject_into_ssl()
+    except ssl.SSLError:
+        pass
 
     from translate import _
     from twitch import Twitch
@@ -27,12 +32,25 @@ if __name__ == "__main__":
     from version import __version__
     from exceptions import CaptchaRequired
     from utils import lock_file, resource_path, set_root_icon
-    from constants import LOGGING_LEVELS, SELF_PATH, FILE_FORMATTER, LOG_PATH, LOCK_PATH
+    from constants import LOGGING_LEVELS, SELF_PATH, FILE_FORMATTER, LOG_PATH, LOCK_PATH, UPDATE_DIR
 
     if TYPE_CHECKING:
         from _typeshed import SupportsWrite
 
     warnings.simplefilter("default", ResourceWarning)
+
+    # Clean up after a previous update
+    old_exe = SELF_PATH.with_suffix(".exe.old")
+    if old_exe.exists():
+        try:
+            old_exe.unlink()
+        except OSError:
+            pass
+    if UPDATE_DIR.exists():
+        try:
+            shutil.rmtree(UPDATE_DIR, ignore_errors=True)
+        except OSError:
+            pass
 
     # import tracemalloc
     # tracemalloc.start(3)

--- a/twitch.py
+++ b/twitch.py
@@ -45,6 +45,10 @@ from constants import (
     CALL,
     MAX_INT,
     DUMP_PATH,
+    SELF_PATH,
+    UPDATE_DIR,
+    WORKING_DIR,
+    IS_PACKAGED,
     COOKIES_PATH,
     MAX_CHANNELS,
     GQL_OPERATIONS,
@@ -561,11 +565,11 @@ class Twitch:
         self.gui.save(force=force)
         self.settings.save(force=force)
 
-    async def check_for_updates(self) -> tuple[bool, str]:
+    async def check_for_updates(self) -> tuple[bool, str, str | None]:
         """
         Check GitHub for a newer version.
 
-        Returns (update_available, message) tuple.
+        Returns (update_available, message, download_url) tuple.
         """
         try:
             # Extract commit hash from version string (e.g., "16.dev.6b23aee" -> "6b23aee")
@@ -578,15 +582,171 @@ class Twitch:
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as response:
                 if response.status != 200:
-                    return False, "Failed to check for updates (HTTP error)"
+                    return False, "Failed to check for updates (HTTP error)", None
                 data = await response.json()
             remote_hash: str = data["sha"][:7]
             remote_date: str = data["commit"]["committer"]["date"][:10]
             if current_hash is not None and current_hash == remote_hash:
-                return False, "You are running the latest version."
-            return True, f"Update available ({remote_hash}, {remote_date})"
+                return False, "You are running the latest version.", None
+            # Find the platform-specific download URL from the dev-build release
+            download_url: str | None = None
+            if IS_PACKAGED:
+                download_url = await self._get_release_download_url(session)
+            return True, f"Update available ({remote_hash}, {remote_date})", download_url
         except Exception:
-            return False, "Failed to check for updates (network error)"
+            return False, "Failed to check for updates (network error)", None
+
+    async def _get_release_download_url(
+        self, session: aiohttp.ClientSession
+    ) -> str | None:
+        """Get the platform-specific ZIP download URL from the dev-build release."""
+        import sys
+        platform_key = {
+            "win32": "Windows",
+            "linux": "Linux",
+            "darwin": "macOS",
+        }.get(sys.platform)
+        if platform_key is None:
+            return None
+        try:
+            async with session.get(
+                f"{GITHUB_REPO_API}/releases/tags/dev-build",
+                headers={"Accept": "application/vnd.github.v3+json"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status != 200:
+                    return None
+                release_data = await response.json()
+            for asset in release_data.get("assets", []):
+                name: str = asset.get("name", "")
+                if platform_key in name and name.endswith(".zip"):
+                    return asset["browser_download_url"]
+        except Exception:
+            pass
+        return None
+
+    async def download_update(
+        self, download_url: str, progress_callback: abc.Callable[[str], Any] | None = None
+    ) -> bool:
+        """
+        Download and apply an update from the given URL.
+
+        On Windows: renames the running EXE to .old, extracts new EXE, writes a restart batch script.
+        On Linux/macOS: overwrites the executable directly (no file lock on running binaries).
+
+        Returns True if the update was applied and the app should restart.
+        """
+        import sys
+        import shutil
+        import zipfile
+        import subprocess
+
+        def _report(msg: str):
+            if progress_callback is not None:
+                progress_callback(msg)
+
+        try:
+            _report("Downloading update...")
+            session = await self.get_session()
+
+            # Download the ZIP
+            UPDATE_DIR.mkdir(parents=True, exist_ok=True)
+            zip_path = UPDATE_DIR / "update.zip"
+            async with session.get(
+                download_url,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as response:
+                if response.status != 200:
+                    _report("Download failed (HTTP error)")
+                    return False
+                total = response.content_length or 0
+                downloaded = 0
+                with open(zip_path, "wb") as f:
+                    async for chunk in response.content.iter_chunked(64 * 1024):
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if total > 0:
+                            pct = int(downloaded * 100 / total)
+                            _report(f"Downloading... {pct}%")
+
+            _report("Extracting update...")
+            # Extract the ZIP
+            extract_dir = UPDATE_DIR / "extracted"
+            if extract_dir.exists():
+                shutil.rmtree(extract_dir)
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zf.extractall(extract_dir)
+
+            # Find the new executable in the extracted files
+            new_exe = None
+            for item in extract_dir.rglob("*"):
+                if item.is_file() and item.suffix in (".exe", ""):
+                    # Match by name pattern - the EXE name from build.spec
+                    if "Twitch Drops Miner" in item.name or item.name == SELF_PATH.name:
+                        new_exe = item
+                        break
+            # Fallback: if only one executable-like file, use it
+            if new_exe is None:
+                exes = [
+                    f for f in extract_dir.rglob("*")
+                    if f.is_file() and (f.suffix == ".exe" or (sys.platform != "win32" and f.stat().st_mode & 0o111))
+                ]
+                if len(exes) == 1:
+                    new_exe = exes[0]
+            if new_exe is None:
+                _report("Update failed: could not find executable in archive")
+                return False
+
+            _report("Applying update...")
+            if sys.platform == "win32":
+                # Windows: can't overwrite running EXE, but CAN rename it
+                old_path = SELF_PATH.with_suffix(".exe.old")
+                # Remove previous .old if it exists
+                if old_path.exists():
+                    old_path.unlink()
+                # Rename running EXE → .old
+                SELF_PATH.rename(old_path)
+                # Move new EXE into place
+                shutil.move(str(new_exe), str(SELF_PATH))
+                # Write a restart batch script
+                bat_path = UPDATE_DIR / "restart.bat"
+                bat_content = (
+                    "@echo off\r\n"
+                    "timeout /t 2 /nobreak >nul\r\n"
+                    f"start \"\" \"{SELF_PATH}\"\r\n"
+                    f"del \"{bat_path}\"\r\n"
+                )
+                bat_path.write_text(bat_content, encoding="utf-8")
+                # Save state before exiting
+                self.save(force=True)
+                _report("Update applied! Restarting...")
+                # Launch the restart script detached
+                subprocess.Popen(
+                    [str(bat_path)],
+                    shell=True,
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
+                    close_fds=True,
+                )
+            else:
+                # Linux/macOS: can overwrite running binary directly
+                import os
+                import stat
+                # Preserve execute permission
+                new_exe.chmod(new_exe.stat().st_mode | stat.S_IEXEC)
+                shutil.move(str(new_exe), str(SELF_PATH))
+                self.save(force=True)
+                _report("Update applied! Restarting...")
+                # Re-exec ourselves
+                os.execv(str(SELF_PATH), sys.argv)
+
+            # Clean up ZIP (leave extracted dir for restart script to handle, or next startup)
+            zip_path.unlink(missing_ok=True)
+            return True
+
+        except Exception as exc:
+            logger.error(f"Update failed: {exc}")
+            _report(f"Update failed: {exc}")
+            return False
 
     def get_priority(self, channel: Channel) -> int:
         """


### PR DESCRIPTION
## Summary

Builds on #995 (update check button) to add **one-click in-place updating** for packaged builds.

- When "Check for Updates" finds a newer version on a packaged build, shows an **Update Now** button alongside the existing "Download manually" link
- Downloads the platform-specific ZIP from the `dev-build` GitHub Release
- Extracts the new executable and applies it in-place
- **Windows**: uses rename-and-replace pattern (running EXE can be renamed but not overwritten), then a batch script trampoline to restart
- **Linux/macOS**: overwrites binary directly and `os.execv()` to re-exec
- Cleans up `.exe.old` and `update_tmp/` on next startup
- Adds SSL fallback for `truststore.inject_into_ssl()` failures

## How it works

1. User clicks "Check for Updates" → compares commit hash via GitHub API
2. If update available + packaged build → fetches platform ZIP URL from `dev-build` release assets
3. User clicks "Update Now" → downloads ZIP with progress %, extracts EXE
4. **Windows path**: `SELF_PATH.rename(.exe.old)` → move new EXE into place → launch `restart.bat` → exit
5. **Linux/macOS path**: `shutil.move()` new EXE over old → `os.execv()` to restart
6. On next startup: delete `.exe.old` and `update_tmp/` directory

## Compatibility

- Mergeable independently from #994 and #995 — no conflicts
- Non-packaged (dev) builds: "Update Now" button is hidden, only shows "Download manually" link
- Includes #995's changes (update check button) as the base

## Test plan

- [ ] Verify "Update Now" downloads and extracts the ZIP on Windows
- [ ] Verify rename-and-replace + batch restart works on Windows
- [ ] Verify direct overwrite + re-exec works on Linux
- [ ] Verify startup cleanup removes `.exe.old` and `update_tmp/`
- [ ] Verify non-packaged dev builds only show "Download manually"
- [ ] Verify download progress percentage updates in the UI