### PR TITLE
Add try/except to websocket receive/send so that reset error is not thrown

### DIFF
--- a/websocket.py
+++ b/websocket.py
@@ -247,7 +247,10 @@ class Websocket:
         ws = self._ws.get_with_default(None)
         assert ws is not None
         while True:
-            raw_message: aiohttp.WSMessage = await ws.receive(timeout=timeout)
+            try:
+                raw_message: aiohttp.WSMessage = await ws.receive(timeout=timeout)
+            except aiohttp.ClientConnectionResetError:
+                raise WebsocketClosed(received=False)
             ws_logger.debug(f"Websocket[{self._idx}] received: {raw_message}")
             if raw_message.type is WSMsgType.TEXT:
                 message: JsonType = json.loads(raw_message.data)
@@ -323,7 +326,10 @@ class Websocket:
         assert ws is not None
         if message["type"] != "PING":
             message["nonce"] = create_nonce(CHARS_ASCII, 30)
-        await ws.send_json(message, dumps=json_minify)
+        try:
+            await ws.send_json(message, dumps=json_minify)
+        except aiohttp.ClientConnectionResetError:
+            raise WebsocketClosed(received=False)
         ws_logger.debug(f"Websocket[{self._idx}] sent: {message}")
 
 


### PR DESCRIPTION
Getting the occasional error in the app:
```
Traceback (most recent call last):
  File "websocket.py", line 167, in _handle
  File "websocket.py", line 283, in _handle_recv
  File "websocket.py", line 250, in _gather_recv
  File "aiohttp/client_ws.py", line 378, in receive
  File "aiohttp/client_ws.py", line 234, in pong
  File "aiohttp/_websocket/writer.py", line 83, in send_frame
  File "aiohttp/_websocket/writer.py", line 151, in _write_websocket_frame
aiohttp.client_exceptions.ClientConnectionResetError: Cannot write to closing transport
```

The websocket code wasn't handling the ClientConnectionResetError, so this code just handles that error so that it doesn't throw an error. This can happen if the websocket is closed while sending/receiving (rare but possible).

Let me know if you like this solution, or if you would prefer a different approach!