### PR TITLE
Replace ClientConnectionResetError with ClientConnectionError

### DIFF
--- a/websocket.py
+++ b/websocket.py
@@ -249,7 +249,7 @@ class Websocket:
         while True:
             try:
                 raw_message: aiohttp.WSMessage = await ws.receive(timeout=timeout)
-            except aiohttp.ClientConnectionResetError:
+            except aiohttp.ClientConnectionError:
                 raise WebsocketClosed(received=False)
             ws_logger.debug(f"Websocket[{self._idx}] received: {raw_message}")
             if raw_message.type is WSMsgType.TEXT:
@@ -328,7 +328,7 @@ class Websocket:
             message["nonce"] = create_nonce(CHARS_ASCII, 30)
         try:
             await ws.send_json(message, dumps=json_minify)
-        except aiohttp.ClientConnectionResetError:
+        except aiohttp.ClientConnectionError:
             raise WebsocketClosed(received=False)
         ws_logger.debug(f"Websocket[{self._idx}] sent: {message}")
 


### PR DESCRIPTION
ClientConnectionResetError doesn't exist in older aiohttp releases (it was added in aiohttp 3.10+), so use ClientConnectionError which is the parent class to avoid increasing dependencies.

This was added in commit d7446a76925e80e1485264508f05bb60a22fc5ab but caused the following error on my Ubuntu 24.04 machine which uses aiohttp 3.9.1:

```
03:13:53 PM: AttributeError: module aiohttp has no attribute ClientConnectionResetError. Did you mean: 'ClientConnectionError'?
03:13:53 PM: WARNING: Websocket[0] reconnecting...
03:13:54 PM: ERROR: Exception in Websocket[0]
03:13:54 PM: Traceback (most recent call last):
03:13:54 PM:   File "/usr/lib/python3/dist-packages/aiohttp/client_ws.py", line 244, in receive
03:13:54 PM:     msg = await self._reader.read()
03:13:54 PM:           ^^^^^^^^^^^^^^^^^^^^^^^^^
03:13:54 PM:   File "/usr/lib/python3/dist-packages/aiohttp/streams.py", line 663, in read
03:13:54 PM:     return await super().read()
03:13:54 PM:            ^^^^^^^^^^^^^^^^^^^^
03:13:54 PM:   File "/usr/lib/python3/dist-packages/aiohttp/streams.py", line 622, in read
03:13:54 PM:     await self._waiter
03:13:54 PM: asyncio.exceptions.CancelledError
03:13:54 PM: 
03:13:54 PM: The above exception was the direct cause of the following exception:
03:13:54 PM: 
03:13:54 PM: Traceback (most recent call last):
03:13:54 PM:   File "/home/iissmart/src/TwitchDropsMiner/websocket.py", line 251, in _gather_recv
03:13:54 PM:     raw_message: aiohttp.WSMessage = await ws.receive(timeout=timeout)
03:13:54 PM:                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
03:13:54 PM:   File "/usr/lib/python3/dist-packages/aiohttp/client_ws.py", line 243, in receive
03:13:54 PM:     async with async_timeout.timeout(timeout or self._receive_timeout):
03:13:54 PM:   File "/usr/lib/python3.12/asyncio/timeouts.py", line 115, in __aexit__
03:13:54 PM:     raise TimeoutError from exc_val
03:13:54 PM: TimeoutError
03:13:54 PM: 
03:13:54 PM: During handling of the above exception, another exception occurred:
03:13:54 PM: 
03:13:54 PM: Traceback (most recent call last):
03:13:54 PM:   File "/home/iissmart/src/TwitchDropsMiner/websocket.py", line 167, in _handle
03:13:54 PM:     await self._handle_recv()
03:13:54 PM:   File "/home/iissmart/src/TwitchDropsMiner/websocket.py", line 286, in _handle_recv
03:13:54 PM:     await self._gather_recv(messages, timeout=0.5)
03:13:54 PM:   File "/home/iissmart/src/TwitchDropsMiner/websocket.py", line 252, in _gather_recv
03:13:54 PM:     except aiohttp.ClientConnectionResetError:
03:13:54 PM:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
03:13:54 PM:   File "/usr/lib/python3/dist-packages/aiohttp/__init__.py", line 240, in __getattr__
03:13:54 PM:     raise AttributeError(f"module {__name__} has no attribute {name}")
```

Reverting to the previous commit, 184abe2cbf92c2c31fdc1a60b63b3ccf3bbfae8b, resolved the issue, so I knew it was caused by the following commit.