### PR TITLE
Fix: handle broken cached image data and wrong resize filter in image cache

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -102,8 +102,10 @@ class ImageCache:
                     image = self._images[img_hash]
                 else:
                     try:
-                        self._images[img_hash] = image = Image_module.open(CACHE_PATH / img_hash)
-                    except (FileNotFoundError, Image_module.UnidentifiedImageError):
+                        loaded = Image_module.open(CACHE_PATH / img_hash)
+                        loaded.load()  # force full decode so broken data is caught here
+                        self._images[img_hash] = image = loaded
+                    except (FileNotFoundError, Image_module.UnidentifiedImageError, OSError):
                         pass
             if image is None:
                 try:
@@ -131,6 +133,10 @@ class ImageCache:
         if photo_key in self._photos:
             return self._photos[photo_key]
         if image.size != size:
-            image = image.resize(size, Image_module.Palette.ADAPTIVE)
+            try:
+                image = image.resize(size, Image_module.Resampling.LANCZOS)
+            except OSError:
+                # broken image data surfaced during resize; fall back to blank placeholder
+                image = Image_module.new("RGB", size, (255, 255, 255))
         self._photos[photo_key] = photo = PhotoImage(master=self._root, image=image)
         return photo


### PR DESCRIPTION
Fixes #1079

- Call .load() immediately after Image.open() when loading from the on-disk cache, so OSError from corrupt/truncated files is caught early and triggers a re-fetch from the network instead of crashing.
- Add OSError handling around image.resize() as a second safety net for images that are corrupt after downloading.
- Replace incorrect Image_module.Palette.ADAPTIVE resampling argument with the correct Image_module.Resampling.LANCZOS in resize().