### PR TITLE
Add an optional "This Week" tab for quicker campaign selection

### DIFF
--- a/FORK_NOTES.md
+++ b/FORK_NOTES.md
@@ -1,0 +1,23 @@
+# Fork notes
+
+This is a personal fork of [DevilXD/TwitchDropsMiner](https://github.com/DevilXD/TwitchDropsMiner)
+(MIT licensed — original copyright retained in `LICENSE`).
+
+## What this fork adds
+
+A **"This Week"** tab (`WeeklyPicker` in `gui.py`) that makes selecting campaigns quicker:
+
+- Lists the drop campaigns for the coming week — every **active** campaign plus **upcoming**
+  ones starting within 7 days — as a checkbox list, read directly from the live inventory.
+- **Hides campaigns you can't complete**: sub-only campaigns, ones already fully claimed, and
+  ones where there isn't enough time left to earn the required watch minutes
+  (`campaign.availability < 1.0`).
+- **🔗 Link account** button on any campaign your account isn't linked to — opens that
+  campaign's Twitch account-linking page in one click.
+- **🔄 Refresh from Twitch** re-fetches the inventory (so newly-linked accounts show up), and
+  the tab auto-re-renders whenever an inventory fetch completes.
+- **✅ Apply selection** writes the ticked games into the priority list, switches to
+  `PRIORITY_ONLY` mode, saves, and triggers a reload — so the miner immediately starts
+  collecting your picks from live participating channels.
+
+All mining/auth/channel-finding is unchanged upstream behaviour.

--- a/gui.py
+++ b/gui.py
@@ -1845,6 +1845,17 @@ class SettingsPanel:
             command=self._manager._twitch.state_change(State.INVENTORY_FETCH),
         ).grid(column=1, row=0)
 
+    def reload_priority_display(self) -> None:
+        # Rebuild the priority listbox and priority-mode combobox from current settings.
+        # Called by the "This Week" tab after it applies a new selection.
+        self._priority_list.delete(0, "end")
+        for name in self._settings.priority:
+            self._priority_list.insert("end", name)
+        self.update_priority_choices()
+        mode = self._settings.priority_mode
+        if mode in self.PRIORITY_MODES:
+            self._vars["priority_mode"].set(self.PRIORITY_MODES[mode])
+
     def clear_selection(self) -> None:
         self._priority_list.selection_clear(0, "end")
         self._exclude_list.selection_clear(0, "end")
@@ -2200,6 +2211,221 @@ class HelpTab:
         self._twitch.change_state(State.RESTART)
 
 
+class WeeklyPicker:
+    """
+    "This Week" tab: lists the active/upcoming drop campaigns for the coming week
+    with a checkbox each. Applying the selection writes the chosen games into the
+    priority list, switches to PRIORITY_ONLY mode, and triggers a reload so the
+    miner starts collecting them from live participating channels.
+    """
+    WEEK_DAYS = 7
+
+    def __init__(self, manager: GUIManager, master: ttk.Widget):
+        self._manager = manager
+        self._settings: Settings = manager._twitch.settings
+        self._frame = master
+        # campaign_id -> (checkbox var, campaign)
+        self._rows: dict[str, tuple[IntVar, DropsCampaign]] = {}
+        bold = nametofont("TkDefaultFont").copy()
+        bold.configure(weight="bold")
+        self._bold = bold
+
+        master.rowconfigure(1, weight=1)
+        master.columnconfigure(0, weight=1)
+
+        # ---- top control bar ----
+        top = ttk.Frame(master, padding=(0, 0, 0, 6))
+        top.grid(column=0, row=0, columnspan=2, sticky="ew")
+        ttk.Label(
+            top,
+            text=(
+                "Tick the campaigns you want to farm this week, then Apply. "
+                "The miner will prioritise those games and collect them from "
+                "live participating channels."
+            ),
+            wraplength=680,
+            justify="left",
+        ).grid(column=0, row=0, columnspan=6, sticky="w", pady=(0, 4))
+        ttk.Button(top, text="🔄 Refresh from Twitch", command=self.refetch).grid(
+            column=0, row=1, sticky="w"
+        )
+        self._hide_ineligible = IntVar(master, 0)
+        ttk.Checkbutton(
+            top,
+            text="Only show ones I can earn (account-linked)",
+            variable=self._hide_ineligible,
+            command=self.refresh,
+        ).grid(column=1, row=1, sticky="w", padx=(10, 0))
+        ttk.Button(top, text="✅ Apply selection ▶ start mining", command=self.apply).grid(
+            column=2, row=1, sticky="w", padx=(10, 0)
+        )
+        self._status = ttk.Label(top, text="", padding=(0, 4, 0, 0))
+        self._status.grid(column=0, row=2, columnspan=6, sticky="w")
+
+        # ---- scrollable list ----
+        self._canvas = tk.Canvas(master, scrollregion=(0, 0, 0, 0), highlightthickness=0)
+        self._canvas.grid(column=0, row=1, sticky="nsew")
+        yscroll = ttk.Scrollbar(master, orient="vertical", command=self._canvas.yview)
+        yscroll.grid(column=1, row=1, sticky="ns")
+        self._canvas.configure(yscrollcommand=yscroll.set)
+        self._canvas.bind(
+            "<Enter>", lambda e: self._canvas.bind_all("<MouseWheel>", self._on_mousewheel)
+        )
+        self._canvas.bind("<Leave>", lambda e: self._canvas.unbind_all("<MouseWheel>"))
+        self._canvas.bind(
+            "<Configure>",
+            lambda e: self._canvas.itemconfigure(self._window, width=e.width),
+        )
+        self._list = ttk.Frame(self._canvas)
+        self._list.columnconfigure(0, weight=1)
+        self._window = self._canvas.create_window(0, 0, anchor="nw", window=self._list)
+        self._list.bind(
+            "<Configure>",
+            lambda e: self._canvas.configure(scrollregion=self._canvas.bbox("all")),
+        )
+
+        manager.tabs.add_view_event(self._on_tab_switched)
+
+    def _on_mousewheel(self, event: tk.Event) -> None:
+        self._canvas.yview_scroll(-1 * (event.delta // 120), "units")
+
+    def _on_tab_switched(self, event: "tk.Event[ttk.Notebook]") -> None:
+        # refresh whenever this tab becomes the visible one
+        if self._manager.tabs._nb.select() == str(self._frame):
+            self.refresh()
+
+    def refetch(self) -> None:
+        # Pull fresh data from Twitch: account-link status, progress, new/expired
+        # campaigns. The fetch is async; fetch_inventory() calls refresh() on this
+        # tab when it finishes, so the rows update themselves once it completes.
+        self._status.config(text="⏳ Refreshing from Twitch… (updates in a few seconds)")
+        self._manager._twitch.change_state(State.INVENTORY_FETCH)
+
+    def configure_theme(self, *, bg: str) -> None:
+        self._canvas.configure(bg=bg)
+
+    def _week_campaigns(self) -> list[DropsCampaign]:
+        now = datetime.now(timezone.utc)
+        horizon = now + timedelta(days=self.WEEK_DAYS)
+        result: list[DropsCampaign] = []
+        for c in self._manager._twitch.inventory:
+            if c.required_minutes <= 0:
+                continue  # skip sub-only / no-watch campaigns
+            if not (c.active or (c.upcoming and c.starts_at <= horizon)):
+                continue
+            if c.finished:
+                continue  # every drop already claimed
+            if c.active and c.availability < 1.0:
+                continue  # not enough time left to finish the required watch minutes
+            if self._hide_ineligible.get() and not c.eligible:
+                continue
+            result.append(c)
+        # active first, then by soonest end date
+        result.sort(key=lambda c: c.ends_at)
+        result.sort(key=lambda c: not c.active)
+        return result
+
+    def refresh(self) -> None:
+        # wipe old rows
+        for child in self._list.winfo_children():
+            child.destroy()
+        self._rows.clear()
+
+        campaigns = self._week_campaigns()
+        if not self._manager._twitch.inventory:
+            ttk.Label(
+                self._list,
+                text="No campaign data yet — log in and let the inventory finish loading, "
+                "then hit Refresh.",
+                padding=8,
+            ).grid(column=0, row=0, sticky="w")
+            return
+        if not campaigns:
+            ttk.Label(
+                self._list,
+                text="No campaigns match for the coming week.",
+                padding=8,
+            ).grid(column=0, row=0, sticky="w")
+            return
+
+        now = datetime.now(timezone.utc)
+        for i, c in enumerate(campaigns):
+            var = IntVar(self._list, int(c.game.name in self._settings.priority))
+            self._rows[c.id] = (var, c)
+
+            row = ttk.Frame(self._list, relief="groove", borderwidth=1, padding=(6, 4))
+            row.grid(column=0, row=i, sticky="ew", pady=1)
+            row.columnconfigure(2, weight=1)
+
+            ttk.Checkbutton(row, variable=var).grid(column=0, row=0, rowspan=2, padx=(0, 6))
+
+            if c.active:
+                days = max((c.ends_at - now).days, 0)
+                badge, style = f"● {days}d left", "green.TLabel"
+            else:
+                days = max((c.starts_at - now).days, 0)
+                badge, style = f"◷ in {days}d", "yellow.TLabel"
+            ttk.Label(row, text=badge, style=style, width=10).grid(
+                column=1, row=0, rowspan=2, sticky="w", padx=(0, 6)
+            )
+
+            ttk.Label(row, text=c.game.name, font=self._bold).grid(
+                column=2, row=0, sticky="w"
+            )
+            n_ch = len(c.allowed_channels)
+            where = f"{n_ch} channel(s)" if n_ch else "any channel"
+            link = "✔ linked" if c.linked else "✖ not linked"
+            meta = (
+                f"{c.name}  ·  {c.total_drops} drop(s), up to {c.required_minutes} min  "
+                f"·  {where}  ·  {link}"
+            )
+            ttk.Label(row, text=meta).grid(column=2, row=1, sticky="w")
+
+            rewards = ", ".join(
+                b.name for d in c.drops for b in d.benefits
+            )
+            if rewards:
+                if len(rewards) > 100:
+                    rewards = rewards[:100] + "…"
+                ttk.Label(row, text=f"🎁 {rewards}", foreground="#888").grid(
+                    column=2, row=2, sticky="w"
+                )
+
+            # Unlinked campaigns can't be earned until the account is connected -
+            # offer a one-click shortcut to the campaign's account-linking page.
+            if not c.linked and c.link_url:
+                ttk.Button(
+                    row,
+                    text="🔗 Link account",
+                    command=lambda url=c.link_url: webopen(url),
+                ).grid(column=3, row=0, rowspan=3, sticky="e", padx=(6, 0))
+
+        self._status.config(
+            text=f"{len(campaigns)} campaign(s) this week. "
+            f"{sum(v.get() for v, _c in self._rows.values())} pre-selected from your priority list."
+        )
+
+    def apply(self) -> None:
+        chosen: list[str] = []
+        for var, c in self._rows.values():
+            if var.get() and c.game.name not in chosen:
+                chosen.append(c.game.name)
+        if not chosen:
+            self._status.config(text="⚠ Nothing ticked — select at least one campaign first.")
+            return
+        self._settings.priority = chosen
+        self._settings.priority_mode = PriorityMode.PRIORITY_ONLY
+        self._settings.alter()
+        self._settings.save(force=True)
+        # keep the Settings tab's priority display in sync
+        self._manager.settings.reload_priority_display()
+        self._status.config(
+            text=f"✅ Applied {len(chosen)} game(s): {', '.join(chosen)}. Reloading…"
+        )
+        # reload inventory + re-evaluate priorities, which kicks off mining
+        self._manager._twitch.change_state(State.INVENTORY_FETCH)
+
+
 ##########################################
 # GUI DEFINITION END / GUI MANAGER START #
 ##########################################
@@ -2278,6 +2504,10 @@ class GUIManager:
         inv_frame = ttk.Frame(root_frame, padding=8)
         self.inv = InventoryOverview(self, inv_frame)
         self.tabs.add_tab(inv_frame, name=_("gui", "tabs", "inventory"))
+        # This Week tab (weekly campaign picker)
+        week_frame = ttk.Frame(root_frame, padding=8)
+        self.weekly = WeeklyPicker(self, week_frame)
+        self.tabs.add_tab(week_frame, name="This Week")
         # Settings tab
         settings_frame = ttk.Frame(root_frame, padding=8)
         self.settings = SettingsPanel(self, settings_frame)
@@ -2660,6 +2890,8 @@ class GUIManager:
         )
         # Inventory canvas
         self.inv.configure_theme(bg=bg)
+        # This Week canvas
+        self.weekly.configure_theme(bg=bg)
 
         # Tk option database for selection/popup list readability (affects Tk-backed widgets)
         # Global selection colors and listbox defaults (covers Combobox dropdown)

--- a/twitch.py
+++ b/twitch.py
@@ -1499,6 +1499,9 @@ class Twitch:
                 switch_triggers.update(campaign.time_triggers)
             self.inventory.append(campaign)
             self._campaigns[campaign.id] = campaign
+        # re-render the "This Week" tab now that inventory (incl. account-link
+        # status) is fresh; it doesn't need the CDN images loaded below
+        self.gui.weekly.refresh()
         # concurrently add the campaigns into the GUI
         # NOTE: this fetches pictures from the CDN, so might be slow without a cache
         status_update(


### PR DESCRIPTION
Hi @DevilXD — thanks for TDM, it's genuinely great to use.

This is an **additive, opt-in** GUI change: a new "This Week" tab that speeds up choosing what to mine. It doesn't touch mining logic or the existing Inventory/Priority tabs — if you never open the tab, behaviour is unchanged.

**What it does**
- Lists active + soon-upcoming (≤7 days) campaigns from the existing in-memory inventory as a checkbox list.
- Hides campaigns you can't complete: sub-only (`required_minutes == 0`), already-claimed, and ones where `campaign.availability < 1.0` (not enough time left).
- A 🔗 Link account button on unlinked campaigns, opening that campaign's `accountLinkURL`.
- **Apply** writes the ticked games into the existing priority list, sets `PRIORITY_ONLY`, saves, and triggers the normal reload.

**Kept within the project goals** (read the README carefully first):
- **No extra Twitch load** — "Refresh" reuses the existing `INVENTORY_FETCH`; the auto-redraw hook in `fetch_inventory` is local GUI only. No new endpoints or polling.
- **Doesn't bypass account linking** — filters only hide rows; eligibility/earn logic is untouched. The Link button just helps satisfy the linking you already require.
- GUI-only, single managed account, drops-only — nothing from the "never" list.

**Testing** — ran against a live account (135 active campaigns); link/refresh/apply verified, plus a headless test of the filter/apply/link-button logic.

Completely understand if a new tab is more UI surface than you want to maintain — no worries if you'd rather not. Happy to adjust or close.
