### PR TITLE
Fix UI freeze during maintenance reloads on Wayland/Linux (#1112)

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -2403,12 +2403,15 @@ class GUIManager:
 
     async def _poll(self):
         """
-        Runs the Tkinter event loop via asyncio without blocking the thread.
+        This runs the Tkinter event loop via asyncio instead of calling mainloop.
+        0.05s gives similar performance and CPU usage.
+        Not ideal, but the simplest way to avoid threads, thread safety,
+        loop.call_soon_threadsafe, futures and all of that.
+        
         Uses TKINTER_DONT_WAIT to prevent Tcl/Tk from hanging inside native
         system calls (e.g. X11/Wayland input contexts) during heavy UI redraws.
         """
-        root = self._root
-        do_one_event = root.dooneevent
+        do_one_event = self._root.dooneevent
         # TKINTER_DONT_WAIT (1 << 1) tells Tcl to return immediately 
         # if no events are ready in the queue.
         DONT_WAIT = 1 << 1

--- a/gui.py
+++ b/gui.py
@@ -2403,19 +2403,26 @@ class GUIManager:
 
     async def _poll(self):
         """
-        This runs the Tkinter event loop via asyncio instead of calling mainloop.
-        0.05s gives similar performance and CPU usage.
-        Not ideal, but the simplest way to avoid threads, thread safety,
-        loop.call_soon_threadsafe, futures and all of that.
+        Runs the Tkinter event loop via asyncio without blocking the thread.
+        Uses TKINTER_DONT_WAIT to prevent Tcl/Tk from hanging inside native
+        system calls (e.g. X11/Wayland input contexts) during heavy UI redraws.
         """
-        update = self._root.update
+        root = self._root
+        do_one_event = root.dooneevent
+        # TKINTER_DONT_WAIT (1 << 1) tells Tcl to return immediately 
+        # if no events are ready in the queue.
+        DONT_WAIT = 1 << 1
+
         while True:
             try:
-                update()
+                # Drain pending Tk events non-blockingly
+                while do_one_event(DONT_WAIT):
+                    pass
             except tk.TclError:
-                # root has been destroyed
+                # Root window was destroyed
                 break
             await asyncio.sleep(0.05)
+
         self._poll_task = None
 
     def close(self, *args) -> int:

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from multiprocessing import freeze_support
 if __name__ == "__main__":
     freeze_support()
     import io
+    import os
     import sys
     import signal
     import asyncio
@@ -39,6 +40,11 @@ if __name__ == "__main__":
 
     if sys.version_info < (3, 10):
         raise RuntimeError("Python 3.10 or higher is required")
+
+    # Suppress X11 Input Method registration on Linux to prevent 
+    # XWayland/Mutter lockups during heavy Tkinter layout updates.
+    if sys.platform.startswith("linux") and "XMODIFIERS" not in os.environ:
+        os.environ["XMODIFIERS"] = "@im=none"
 
     class Parser(argparse.ArgumentParser):
         def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
This PR resolves the UI freeze/hang under Linux desktop environments (such as GNOME/Wayland) during maintenance reloads and heavy interface refreshes (#1112).

Root Cause:

Backtraces showed that calling root.update() forced synchronous geometry calculations (ArrangeGrid). Under Wayland/XWayland, Tkinter attempts to recreate the X Input Context (CreateXIC -> _xcb_conn_wait) and hangs indefinitely waiting for a response from the compositor.

Changes:

1. Non-blocking Event Loop: Replaced root.update() in _poll() with root.dooneevent(DONT_WAIT). This drains pending Tkinter events without allowing Tcl to enter a blocking native poll().
2. XMODIFIERS Fallback: Set os.environ["XMODIFIERS"] = "@im=none" on Linux startup if not already defined to prevent Tkinter from making synchronous XIM calls during widget recreation.