### PR TITLE
Improve watch and settings reliability

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -6,7 +6,6 @@ import json
 import asyncio
 import logging
 from base64 import b64encode
-from functools import cached_property
 from typing import Any, SupportsInt, cast, TYPE_CHECKING
 
 import aiohttp
@@ -43,7 +42,7 @@ class Stream:
         self.title: str = title
         self._stream_url: URLType | None = None
 
-    @cached_property
+    @property
     def _watch_payload(self) -> list[JsonType]:
         return [
             {
@@ -66,13 +65,13 @@ class Stream:
             }
         ]
 
-    @cached_property
+    @property
     def spade_payload(self) -> JsonType:
         return {
             "data": (b64encode(json_minify(self._watch_payload).encode("utf8"))).decode("utf8")
         }
 
-    @cached_property
+    @property
     def gql_payload(self) -> GQLQuery:
         return GQLQuery(
             (
@@ -490,6 +489,10 @@ class Channel:
             async with self._twitch.request(
                 "POST", self._spade_url, data=self._stream.spade_payload
             ) as response:
+                if response.status in (404, 410):
+                    # Spade URLs can change when Twitch deploys a new client.
+                    # Force a fresh extraction on the next watch attempt.
+                    self._spade_url = None
                 return response.status == 204
         except RequestException:
             return False

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from channel import Stream
+from utils import json_load, json_save
+
+
+class JsonReliabilityTests(unittest.TestCase):
+    def test_save_keeps_previous_valid_file_as_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory, "settings.json")
+
+            json_save(path, {"value": 1})
+            json_save(path, {"value": 2})
+
+            self.assertEqual(json.loads(path.read_text(encoding="utf8")), {"value": 2})
+            self.assertEqual(
+                json.loads(path.with_name("settings.json.bak").read_text(encoding="utf8")),
+                {"value": 1},
+            )
+
+    def test_load_recovers_corrupt_main_file_without_consuming_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory, "settings.json")
+            backup_path = path.with_name("settings.json.bak")
+            path.write_text("{broken", encoding="utf8")
+            backup_path.write_text('{"value": 7}', encoding="utf8")
+
+            loaded = json_load(path, {"value": 0})
+
+            self.assertEqual(loaded, {"value": 7})
+            self.assertEqual(json.loads(path.read_text(encoding="utf8")), {"value": 7})
+            self.assertEqual(json.loads(backup_path.read_text(encoding="utf8")), {"value": 7})
+
+    def test_load_promotes_completed_temporary_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory, "settings.json")
+            new_path = path.with_name("settings.json.new")
+            path.write_text('{"value": 1}', encoding="utf8")
+            new_path.write_text('{"value": 2}', encoding="utf8")
+
+            loaded = json_load(path, {"value": 0})
+
+            self.assertEqual(loaded, {"value": 2})
+            self.assertFalse(new_path.exists())
+            self.assertEqual(json.loads(path.read_text(encoding="utf8")), {"value": 2})
+
+
+class StreamPayloadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        twitch = SimpleNamespace(
+            settings=SimpleNamespace(available_drops_check=False),
+            _auth_state=SimpleNamespace(user_id="42"),
+        )
+        channel = SimpleNamespace(id=123, _login="example", _twitch=twitch)
+        self.stream = Stream(
+            channel,
+            id=456,
+            game={"id": "789", "name": "Example Game"},
+            viewers=10,
+            title="Example",
+        )
+
+    def test_spade_payload_refreshes_client_time(self) -> None:
+        with patch("channel.isonow", side_effect=["first", "second"]):
+            first = json.loads(base64.b64decode(self.stream.spade_payload["data"]))
+            second = json.loads(base64.b64decode(self.stream.spade_payload["data"]))
+
+        self.assertEqual(first[0]["properties"]["client_time"], "first")
+        self.assertEqual(second[0]["properties"]["client_time"], "second")
+
+    def test_gql_payload_contains_current_watch_event(self) -> None:
+        with patch("channel.isonow", return_value="now"):
+            payload = self.stream.gql_payload
+
+        encoded = payload["variables"]["input"]["data"]
+        event = json.loads(gzip.decompress(base64.b64decode(encoded)))
+        self.assertEqual(event[0]["properties"]["client_time"], "now")
+        self.assertEqual(event[0]["properties"]["broadcast_id"], "456")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import os
 import re
+import shutil
 import sys
 import json
 import random
@@ -243,19 +244,35 @@ def merge_json(obj: JsonType, template: Mapping[Any, Any]) -> None:
 
 def json_load(path: Path, defaults: _JSON_T, *, merge: bool = True) -> _JSON_T:
     new_path: Path = path.with_name(f"{path.name}.new")
+    backup_path: Path = path.with_name(f"{path.name}.bak")
     combined: JsonType | None = None
-    # try new file first
-    if new_path.exists():
+    # Prefer the newest temporary file, then the main file, then the backup.
+    # The temporary file can be left behind if the application is interrupted
+    # during a save; the backup protects against a damaged main file.
+    for candidate in (new_path, path, backup_path):
+        if not candidate.exists():
+            continue
         try:
-            with new_path.open('r', encoding="utf8") as file:
-                combined = _remove_missing(json.load(file, object_hook=_deserialize))
-        except json.JSONDecodeError:
-            # remove invalid file
-            new_path.unlink()
-    # try the old file
-    if combined is None and path.exists():
-        with path.open('r', encoding="utf8") as file:
-            combined = _remove_missing(json.load(file, object_hook=_deserialize))
+            with candidate.open('r', encoding="utf8") as file:
+                loaded = json.load(file, object_hook=_deserialize)
+            if not isinstance(loaded, dict):
+                raise TypeError("JSON root must be an object")
+            combined = _remove_missing(loaded)
+            if candidate == new_path:
+                try:
+                    candidate.replace(path)
+                except OSError:
+                    pass
+            elif candidate == backup_path:
+                try:
+                    shutil.copy2(candidate, new_path)
+                    new_path.replace(path)
+                except OSError:
+                    new_path.unlink(missing_ok=True)
+            break
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            if candidate == new_path:
+                candidate.unlink(missing_ok=True)
     # handle defaults and merging
     if combined is None:
         combined = dict(defaults)  # always make a copy of defaults
@@ -266,8 +283,26 @@ def json_load(path: Path, defaults: _JSON_T, *, merge: bool = True) -> _JSON_T:
 
 def json_save(path: Path, contents: Mapping[Any, Any], *, sort: bool = False) -> None:
     new_path: Path = path.with_name(f"{path.name}.new")
+    backup_path: Path = path.with_name(f"{path.name}.bak")
+    backup_tmp_path: Path = backup_path.with_name(f"{backup_path.name}.new")
     with new_path.open('w', encoding="utf8") as file:
         json.dump(contents, file, default=_serialize, sort_keys=sort, indent=4)
+        file.flush()
+        try:
+            os.fsync(file.fileno())
+        except OSError:
+            pass
+    if path.exists():
+        try:
+            shutil.copy2(path, backup_tmp_path)
+            with backup_tmp_path.open('rb') as backup_file:
+                try:
+                    os.fsync(backup_file.fileno())
+                except OSError:
+                    pass
+            backup_tmp_path.replace(backup_path)
+        except OSError:
+            backup_tmp_path.unlink(missing_ok=True)
     new_path.replace(path)
 
 


### PR DESCRIPTION
## Summary

This PR improves reliability in two areas:

- rebuilds Spade watch-event payloads for every send so `client_time` and other stream metadata stay current
- clears a cached Spade endpoint after HTTP 404/410 so the next watch attempt extracts a fresh URL
- makes JSON persistence more resilient with atomic replacement and a last-known-good `.bak` file
- recovers settings/cache data from a valid `.new` or `.bak` file when the primary JSON file is damaged
- adds regression tests for payload freshness and JSON recovery

## Motivation

`Stream._watch_payload`, `spade_payload`, and `gql_payload` were cached properties. As a result, the first generated `client_time` and other mutable event fields could be reused for later watch events.

A Spade URL could also remain cached after Twitch retired it. Separately, malformed settings or cache JSON could prevent the application from starting even when recoverable data was available.

## Implementation details

- watch payload properties are recomputed on access
- HTTP 404/410 invalidates `Channel._spade_url`
- JSON saves are flushed and synced before atomic replacement
- the previous valid file is retained as `<name>.bak`
- load recovery order is `.new`, primary file, then `.bak`
- recovered temporary/backup data is promoted back to the primary path when possible

## Validation

- `python -m unittest discover -s tests -v` — 5 tests passed
- Python bytecode compilation passed
- Windows, macOS, Linux x86_64, and Linux aarch64 builds passed in the fork