### PR TITLE
Fix Linux AppIndicator library path detection on non-multiarch distros

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -76,10 +76,9 @@ if sys.platform == "linux":
         Path("/usr/lib64"),  # Fedora/RHEL
         Path("/usr/lib"),  # Arch and other single-dir distros
     ]
-    libraries_path: Path = next(
-        (p for p in candidate_library_paths if (p / "libayatana-appindicator3.so.1").exists()),
-        candidate_library_paths[0],
-    )
+    for libraries_path in candidate_library_paths:
+        if (libraries_path / "libayatana-appindicator3.so.1").exists():
+            break
     datas.append(
         (libraries_path / "girepository-1.0/AyatanaAppIndicator3-0.1.typelib", "gi_typelibs")
     )

--- a/build.spec
+++ b/build.spec
@@ -71,9 +71,15 @@ hiddenimports: list[str] = [
 if sys.platform == "linux":
     # Needed files for better system tray support on Linux via pystray (AppIndicator backend).
     arch: str = platform.machine()
-    libraries_path: Path = Path(f"/usr/lib/{arch}-linux-gnu")
-    if not libraries_path.exists():
-        libraries_path = Path("/usr/lib64")
+    candidate_library_paths: list[Path] = [
+        Path(f"/usr/lib/{arch}-linux-gnu"),  # Debian/Ubuntu multiarch
+        Path("/usr/lib64"),  # Fedora/RHEL
+        Path("/usr/lib"),  # Arch and other single-dir distros
+    ]
+    libraries_path: Path = next(
+        (p for p in candidate_library_paths if (p / "libayatana-appindicator3.so.1").exists()),
+        candidate_library_paths[0],
+    )
     datas.append(
         (libraries_path / "girepository-1.0/AyatanaAppIndicator3-0.1.typelib", "gi_typelibs")
     )


### PR DESCRIPTION
## Summary
- `build.spec` picks the AppIndicator library directory by checking whether `/usr/lib/<arch>-linux-gnu` (the Debian/Ubuntu multiarch path) *exists*, not whether it actually contains `libayatana-appindicator3.so.1`.
- On Arch-based distros (tested on CachyOS) that directory can exist for unrelated reasons (e.g. created by another package as an empty compat dir) while the real libraries live in the flat `/usr/lib`, so the build fails with:
  ```
  ERROR: Unable to find '/usr/lib/x86_64-linux-gnu/libayatana-appindicator3.so.1' when adding binary and data files.
  ```
- This change checks each candidate directory for the actual library file and picks the first one that has it, falling back to the original default if none match (preserving the existing error message/behavior for genuinely missing dependencies).

## Test plan
- [x] Reproduced the failing build on CachyOS (Arch-based) with `libayatana-appindicator` and friends installed via pacman.
- [x] Confirmed `pyinstaller build.spec` now finds the library correctly and proceeds past this step.
- [x] Built from source successfully. 

Disclaimer: I had Claude Code help with writing the code and doing the fork/push/PR, but I did manually review every step and read the code myself (it's just 9 lines).