### PR TITLE
Add claim logs and manual.txt update

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -173,11 +173,22 @@ class BaseDrop:
                 f"{self.rewards_text()} "
                 f"({self.campaign.claimed_drops}/{self.campaign.total_drops})"
             )
+            claim_text_single_line = claim_text.replace('\n', ' ')
+
             # two different claim texts, becase a new line after the game name
             # looks ugly in the output window - replace it with a space
             self._twitch.print(
-                _("status", "claimed_drop").format(drop=claim_text.replace('\n', ' '))
+                _("status", "claimed_drop").format(drop=claim_text_single_line)
             )
+
+            # Add claim to info logs
+            logger.info(msg= (
+                f"Claimed drop: {claim_text_single_line}|"
+                f"{self.campaign.game.name};"
+                f"{self.rewards_text()};"
+                f"{self.campaign.claimed_drops}/{self.campaign.total_drops}"
+            ))
+
             self._twitch.gui.tray.notify(claim_text, _("gui", "tray", "notification_title"))
         else:
             logger.error(f"Drop claim has potentially failed! Drop ID: {self.id}")

--- a/inventory.py
+++ b/inventory.py
@@ -184,9 +184,9 @@ class BaseDrop:
             # Add claim to info logs
             logger.info(msg= (
                 f"Claimed drop: {claim_text_single_line}|"
-                f"{self.campaign.game.name};"
-                f"{self.rewards_text()};"
-                f"{self.campaign.claimed_drops}/{self.campaign.total_drops}"
+                f"game={self.campaign.game.name};"
+                f"drop={self.rewards_text()};"
+                f"campaign_progress={self.campaign.claimed_drops}/{self.campaign.total_drops}"
             ))
 
             self._twitch.gui.tray.notify(claim_text, _("gui", "tray", "notification_title"))

--- a/manual.txt
+++ b/manual.txt
@@ -4,26 +4,33 @@
 
 Available command line arguments:
 
+• --version
+	Show application version information.
+
 • --tray
 	Start the application as minimised into tray.
-• -v
-	Increase verbosity level. Can be stacked up several times (-vv, -vvv, etc.) to show
-	increasingly more information during application runtime.
+
 • --log
 	Enables logging of runtime information into a 'log.txt' file. Verbosity level of this logging
-	matches the level set by `-v`.
+	matches the level set by '-v'.
+
+• -v
+    Increase output verbosity. Repeat the option to enable more
+    detailed logging:
+		-v      Show warnings
+		-vv     Show informational messages
+		-vvv    Show call tracing
+		-vvvv   Show debug messages
+
 • --dump
 	Start the application in a data-dump mode, where a 'dump.dat' file is created.
 	The file contains anonymous raw Twitch API data, studying of which can help troubleshoot
 	issues with the application. The application automatically closes shortly after launching,
 	once dumping is finished.
-• --version
-	Show application version information.
 
 Note: Additional settings are available within the application GUI.
 
 Exit codes:
-
 • 0: Application exited successfully
 • 1: Exit caused by the CAPTCHA or a Fatal Exception
 • 2: Incorrect command line arguments


### PR DESCRIPTION
Added an info log when a claim occurs to better reflect the OutputConsole. Additionally, I added the claimed drop information, separated by a pipe `|`, with the individual values delimited by semicolons `;` so the log data can be parsed and processed more easily.

An example claim-log would look like the following:
`Claimed drop: Albion Online 2x Dragonfire Chest (1/1)|game=Albion Online;drop=2x Dragonfire Chest;campaign_progress=1/1`

Updated the manual.txt log entry and reordered the entries into a more logical structure.