### PR TITLE
Handle "request cancelled" GQL error

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -1352,6 +1352,7 @@ class Twitch:
                             elif (
                                 error_dict["message"] in (
                                     "service timeout",
+                                    "request cancelled",
                                     "service unavailable",
                                     "context deadline exceeded",
                                 )


### PR DESCRIPTION
Twitch's GraphQL API can return "request cancelled" when an upstream context is aborted or times out under load. Treat this transient error as retryable in the exponential backoff loop instead of raising a fatal GQLException.

Here's the log from my machine when I saw it:
```
11:10:06: Fatal error encountered:
11:10:06: 
11:10:06: Traceback (most recent call last):
11:10:06:   File "main.py", line 167, in main
11:10:06:   File "twitch.py", line 599, in run
11:10:06:   File "twitch.py", line 648, in _run
11:10:06:   File "twitch.py", line 1443, in fetch_inventory
11:10:06:   File "asyncio\tasks.py", line 571, in _wait_for_one
11:10:06:   File "twitch.py", line 1400, in fetch_campaigns
11:10:06:   File "twitch.py", line 1362, in gql_request
11:10:06: exceptions.GQLException: [{'message': 'request cancelled'}]
11:10:06: 
11:10:06: Exiting...
11:10:07: 
11:10:07: Application Terminated.
11:10:07: Close the window to exit the application.
```